### PR TITLE
Pivot Agen8 to multi-harness orchestrator with observability aliases

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -4,6 +4,25 @@ The role of this file is to describe common mistakes and confusion points that a
 
 We are developing; there is no need for backward compatibility. We just delete the database and start afresh.
 
+## Pivot guardrails (orchestrator-first)
+
+1. Identity and lane
+   - Agen8 is orchestrator-first and adapter-driven.
+   - Treat the core as a contract plane for task routing + observability across harnesses, not as a single harness product.
+
+2. No implicit bootstrapping
+   - Daemon/runtime flows must not implicitly create runs or tasks.
+   - Bootstrapping is only valid when explicitly requested by user/API command.
+
+3. Adapter contract requirements
+   - Every non-native harness adapter must emit harness lifecycle events (`harness.selected`, `harness.run.start`, `harness.run.complete`/`harness.run.error`, `harness.usage.reported`).
+   - Adapters must return best-effort usage and cost fields, even if provider telemetry is partial.
+   - Keep adapter fields in task metadata (`harnessId`, `harnessRunRef`) unless/until schema migration is explicitly approved.
+
+4. Scope control for native harness work
+   - Native harness changes are allowed for parity/compatibility, but must not block orchestrator roadmap work.
+   - Prioritize cross-harness routing, protocol consistency, and observability over native-only feature expansion.
+
 ## Session learnings (team-only reviewer pipeline)
 
 1. Reviewer -> coordinator handoff is mandatory.

--- a/AGENT.md
+++ b/AGENT.md
@@ -23,6 +23,25 @@ We are developing; there is no need for backward compatibility. We just delete t
    - Native harness changes are allowed for parity/compatibility, but must not block orchestrator roadmap work.
    - Prioritize cross-harness routing, protocol consistency, and observability over native-only feature expansion.
 
+5. External harness orchestration semantics (critical)
+   - External harness adapters are execution engines; they do not own task state.
+   - Agen8 remains the source of truth for all task/run lifecycle mutations (create/claim/complete/retry/escalate).
+   - "Adapter runs a task" is not the same as "orchestration works." True orchestration requires the coordinator to issue actionable delegation intents that Agen8 applies.
+
+6. Current codex-cli reality (do not assume parity with native)
+   - Today, `codex-cli` is invoked per task and returns text/usage only.
+   - It does not directly call Agen8 host tools (`task_create`, `task_review`) in the external adapter path.
+   - Therefore external coordinator runs currently cannot autonomously spawn/assign agents unless Agen8 provides an action bridge.
+
+7. Required bridge contract for external coordinators
+   - External coordinator outputs must be parsed into a strict, machine-readable action envelope (for example: create-task, assign-role, review-decision).
+   - Agen8 must validate and apply those actions through existing task services; adapters must never write DB state directly.
+   - Enforce idempotency and safety limits (dedupe key, max actions per cycle, timeout/cancel handling, malformed output retry policy).
+
+8. Config-first harness control
+   - Harness selection and defaults should be controlled in `config.toml`; CLI flags are overrides, not primary policy.
+   - Selection precedence remains task metadata -> run runtime -> env default -> `agen8-native`.
+
 ## Session learnings (team-only reviewer pipeline)
 
 1. Reviewer -> coordinator handoff is mandatory.

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,0 +1,85 @@
+# HANDOVER
+
+Date: 2026-02-26
+Branch: `codex/pivot-harness-orchestrator`
+Upstream: `origin/codex/pivot-harness-orchestrator`
+PR: https://github.com/tinoosan/agen8/pull/16
+
+## 1. What was completed before this handoff
+Recent commits already on branch:
+- `b945944` Pivot to multi-harness orchestrator with harness routing and observability
+- `27074aa` Fix adapter total token preservation and costs RPC error handling
+- `f6ec975` Stop persisting/emitting external harness cost
+- `311a6c8` Add harness defaults to config.toml runtime config
+- `3539817` Document harness config.toml defaults and CLI observability aliases
+
+Implemented baseline:
+- Harness contract + registry + selector.
+- Native path wired as adapter-backed.
+- `codex-cli` adapter registered and executable.
+- Harness selection precedence implemented.
+- Harness metadata surfaced in task RPC/list/state.
+- Observability aliases (`status`, `feed`, `trace`, `costs`) added.
+- Config-first harness defaults documented and wired.
+
+## 2. Clarification reached today (critical)
+The user clarified orchestration intent:
+- External harness must not be “text only”.
+- Coordinator must be able to orchestrate by creating work and spawning workers dynamically.
+- This requires an Agen8 action-application bridge, not just adapter execution.
+
+Current reality:
+- External `codex-cli` path runs per task and returns text/usage.
+- It does not directly invoke Agen8 host tools in external mode.
+- Therefore, without Phase 2 bridge, external coordinator cannot truly orchestrate autonomously.
+
+## 3. Phase 2 decisions locked
+- Output contract: strict JSON envelope.
+- Apply path: session post-adapter (adapter remains execution-only).
+- Spawn model: dynamic spawn + assign required in Phase 2.
+
+## 4. Phase 2 implementation plan file
+Planned canonical plan file:
+- `docs/plans/phase2-external-coordinator-actions.md`
+
+Core components to add:
+- `pkg/harness/actions/*` (contract/parser/validator/idempotency)
+- `internal/app/external_coordinator_bridge.go`
+- session hook in `pkg/agent/session/session.go`
+- codex envelope builder in `pkg/harness/codexcli/coordinator_envelope.go`
+- runtime config additions in `internal/app/runtime_config.go`
+
+## 5. Repo state at handoff
+`git status --short --branch` at handoff:
+- `## codex/pivot-harness-orchestrator...origin/codex/pivot-harness-orchestrator`
+- `M AGENT.md`
+- `M agen8`
+
+Notes:
+- `AGENT.md` was updated with explicit external orchestration semantics and bridge guardrails.
+- `agen8` appears as a modified built binary artifact in working tree.
+
+## 6. Immediate next steps for implementing agent
+1. Commit/keep `AGENT.md` update as intended guardrail.
+2. Add phase-2 plan file under `docs/plans/`.
+3. Implement `pkg/harness/actions` with strict validation + deterministic ids.
+4. Add session post-adapter apply hook behind config gate.
+5. Implement supervisor-backed bridge for task apply + deterministic spawn.
+6. Add codex coordinator JSON-only envelope prompt builder.
+7. Extend runtime config + docs with action-mode controls.
+8. Add unit/session/integration tests and run `go test ./...`.
+
+## 7. Acceptance criteria for next phase
+- External coordinator can emit valid actions that result in:
+  - role task creation
+  - spawned worker run creation
+  - initial task assignment to spawned run
+- Retries are idempotent (no duplicate runs/tasks).
+- Invalid envelope/action set fails safely with explicit error.
+- Existing orchestrator behavior remains unchanged when action mode is disabled.
+
+## 8. Risks to watch
+- Duplicate side effects on retry/replay without deterministic ids.
+- Role-validation gaps causing misrouted tasks.
+- Coupling adapter to DB mutation (must avoid; bridge owns mutations).
+- Action parsing fragility if output is not forced JSON-only.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Agen8
 
-Agen8 Core is a local agentic runtime that exposes an interactive CLI for launching sessions, resuming previous runs, and inspecting every artifact the agent creates. It builds on a virtual filesystem (VFS) abstraction so tooling remains explicit, auditable, and reproducible.
+Agen8 Contract Plane is an orchestrator-first runtime for routing work across multiple harnesses while keeping one control-plane for tasks, runs, artifacts, and observability. It builds on a virtual filesystem (VFS) abstraction so tooling remains explicit, auditable, and reproducible.
 
 ## Table of Contents
 
@@ -43,7 +43,8 @@ Sessions share a workspace under `dataDir/agents/<agentId>` and persist history 
 ### Rapid reference
 
 - `./agen8 monitor` attaches a minimalist observer to a running agent (start the daemon first).
-- Tail structured logs with `./agen8 logs --follow` and tool activity with `./agen8 activity --follow`.
+- Tail structured logs with `./agen8 logs --follow` or `./agen8 feed`, and deep traces with `./agen8 trace`.
+- Use `./agen8 status` for one-shot runtime health and `./agen8 costs` for per-run/session usage totals.
 - When you need flag help, run `./agen8 --help` or read [docs/cli-usage.md](docs/cli-usage.md).
 
 ## The Vision: Kubernetes for Agents

--- a/cmd/agen8/cmd/coordinator_shell.go
+++ b/cmd/agen8/cmd/coordinator_shell.go
@@ -35,7 +35,7 @@ func runCoordinatorShell(cmd *cobra.Command, sessionID string, runID string, tea
 	fmt.Fprintf(cmd.OutOrStdout(), "Coordinator session %s (mode=%s, run=%s)\n", state.sessionID, state.mode, state.runID)
 	fmt.Fprintln(cmd.OutOrStdout(), "Commands: /new /attach <session-id> /pause /resume /stop /reviewer /reconnect /help /quit")
 	for {
-		if next, err := printLogsBatch(cmd, state.runID, nil, activityCursor, 20); err == nil && next > 0 {
+		if next, err := printLogsBatch(cmd, state.runID, nil, "", activityCursor, 20); err == nil && next > 0 {
 			activityCursor = next
 		}
 		if latest, err := rpcLatestSeq(cmd, state.runID); err == nil {

--- a/cmd/agen8/cmd/dashboard_command.go
+++ b/cmd/agen8/cmd/dashboard_command.go
@@ -112,18 +112,22 @@ func renderDashboardOnce(cmd *cobra.Command, sessionID string) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
-	fmt.Fprintln(w, "ROLE\tRUN\tSTATUS\tPROFILE\tWORKER\tHEARTBEAT\tSTARTED")
+	fmt.Fprintln(w, "ROLE\tRUN\tHARNESS\tSTATUS\tPROFILE\tWORKER\tHEARTBEAT\tSTARTED")
 	for _, agent := range agents.Agents {
 		role := strings.TrimSpace(agent.Role)
 		if strings.EqualFold(strings.TrimSpace(item.Mode), "standalone") {
 			role = "-"
 		}
 		effective := strings.TrimSpace(agent.Status)
+		harnessID := "-"
 		worker := "-"
 		heartbeat := "-"
 		if rs, ok := effectiveByRun[strings.TrimSpace(agent.RunID)]; ok {
 			if v := strings.TrimSpace(rs.EffectiveStatus); v != "" {
 				effective = v
+			}
+			if v := strings.TrimSpace(rs.HarnessID); v != "" {
+				harnessID = v
 			}
 			if rs.WorkerPresent {
 				worker = "yes"
@@ -136,9 +140,10 @@ func renderDashboardOnce(cmd *cobra.Command, sessionID string) error {
 		}
 		fmt.Fprintf(
 			w,
-			"%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			"%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			blankDash(role),
 			blankDash(strings.TrimSpace(agent.RunID)),
+			blankDash(harnessID),
 			blankDash(effective),
 			blankDash(strings.TrimSpace(agent.Profile)),
 			worker,

--- a/cmd/agen8/cmd/events_commands.go
+++ b/cmd/agen8/cmd/events_commands.go
@@ -16,6 +16,7 @@ var (
 	logsRunID     string
 	logsSessionID string
 	logsAgentID   string
+	logsHarnessID string
 	logsTypes     []string
 	logsFollow    bool
 	logsLimit     int
@@ -31,7 +32,7 @@ var logsCmd = &cobra.Command{
 		}
 		typesFilter := normalizeTypeFilter(logsTypes)
 		return followEventRuns(cmd, runIDs, logsFollow, logsLimit, func(cmd *cobra.Command, runID string, afterSeq int64, limit int) (int64, error) {
-			return printLogsBatch(cmd, runID, typesFilter, afterSeq, limit)
+			return printLogsBatch(cmd, runID, typesFilter, strings.TrimSpace(logsHarnessID), afterSeq, limit)
 		})
 	},
 }
@@ -73,7 +74,7 @@ func followEventRuns(cmd *cobra.Command, runIDs []string, follow bool, limit int
 	}
 }
 
-func printLogsBatch(cmd *cobra.Command, runID string, typesFilter []string, afterSeq int64, limit int) (int64, error) {
+func printLogsBatch(cmd *cobra.Command, runID string, typesFilter []string, harnessID string, afterSeq int64, limit int) (int64, error) {
 	var out protocol.LogsQueryResult
 	if err := rpcCall(cmd.Context(), protocol.MethodLogsQuery, protocol.LogsQueryParams{
 		RunID:    runID,
@@ -85,6 +86,9 @@ func printLogsBatch(cmd *cobra.Command, runID string, typesFilter []string, afte
 		return afterSeq, err
 	}
 	for _, ev := range out.Events {
+		if harnessID != "" && !strings.EqualFold(eventHarnessID(ev), harnessID) {
+			continue
+		}
 		fmt.Fprintln(cmd.OutOrStdout(), formatEventLine(ev))
 	}
 	if out.Next > 0 {
@@ -99,7 +103,24 @@ func formatEventLine(ev types.EventRecord) string {
 	if msg == "" {
 		msg = "-"
 	}
-	return fmt.Sprintf("%s  %s  %s  %s", ts, strings.TrimSpace(ev.RunID), strings.TrimSpace(ev.Type), msg)
+	harnessID := eventHarnessID(ev)
+	if harnessID == "" {
+		harnessID = "-"
+	}
+	return fmt.Sprintf("%s  %s  %s  %s  %s", ts, strings.TrimSpace(ev.RunID), strings.TrimSpace(ev.Type), harnessID, msg)
+}
+
+func eventHarnessID(ev types.EventRecord) string {
+	if len(ev.Data) == 0 {
+		return ""
+	}
+	if v := strings.TrimSpace(ev.Data["harnessId"]); v != "" {
+		return v
+	}
+	if v := strings.TrimSpace(ev.Data["harnessID"]); v != "" {
+		return v
+	}
+	return ""
 }
 
 func normalizeTypeFilter(in []string) []string {
@@ -215,6 +236,7 @@ func init() {
 	logsCmd.Flags().StringVar(&logsRunID, "run-id", "", "run id to query")
 	logsCmd.Flags().StringVar(&logsSessionID, "session-id", "", "session id scope (defaults to active project session)")
 	logsCmd.Flags().StringVar(&logsAgentID, "agent", "", "agent/run id alias for filtering")
+	logsCmd.Flags().StringVar(&logsHarnessID, "harness-id", "", "filter events by harness id")
 	logsCmd.Flags().StringSliceVar(&logsTypes, "type", nil, "event type filter (repeat or comma-separated)")
 	logsCmd.Flags().BoolVar(&logsFollow, "follow", true, "follow log updates")
 	logsCmd.Flags().IntVar(&logsLimit, "limit", 200, "max events per poll per run")

--- a/cmd/agen8/cmd/observe_aliases.go
+++ b/cmd/agen8/cmd/observe_aliases.go
@@ -115,16 +115,20 @@ var costsCmd = &cobra.Command{
 		}
 
 		var totals protocol.SessionGetTotalsResult
-		_ = rpcCall(cmd.Context(), protocol.MethodSessionGetTotals, protocol.SessionGetTotalsParams{
+		if err := rpcCall(cmd.Context(), protocol.MethodSessionGetTotals, protocol.SessionGetTotalsParams{
 			ThreadID: protocol.ThreadID(sessionID),
 			TeamID:   strings.TrimSpace(item.TeamID),
 			RunID:    strings.TrimSpace(item.CurrentRunID),
-		}, &totals)
+		}, &totals); err != nil {
+			return fmt.Errorf("session.getTotals: %w", err)
+		}
 
 		var runtimeState protocol.RuntimeGetSessionStateResult
-		_ = rpcCall(cmd.Context(), protocol.MethodRuntimeGetSessionState, protocol.RuntimeGetSessionStateParams{
+		if err := rpcCall(cmd.Context(), protocol.MethodRuntimeGetSessionState, protocol.RuntimeGetSessionStateParams{
 			SessionID: sessionID,
-		}, &runtimeState)
+		}, &runtimeState); err != nil {
+			return fmt.Errorf("runtime.getSessionState: %w", err)
+		}
 
 		fmt.Fprintf(cmd.OutOrStdout(), "Session %s totals: tokens=%d cost=$%.4f\n", sessionID, totals.TotalTokens, totals.TotalCostUSD)
 		w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)

--- a/cmd/agen8/cmd/observe_aliases.go
+++ b/cmd/agen8/cmd/observe_aliases.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/tinoosan/agen8/pkg/protocol"
+)
+
+var (
+	statusSessionID string
+
+	feedRunID     string
+	feedSessionID string
+	feedAgentID   string
+	feedHarnessID string
+	feedTypes     []string
+	feedLimit     int
+
+	traceRunID     string
+	traceSessionID string
+	traceAgentID   string
+	traceHarnessID string
+	traceLimit     int
+
+	costsSessionID string
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Alias for dashboard --once",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		prevSessionID := dashboardSessionID
+		prevOnce := dashboardOnce
+		dashboardSessionID = strings.TrimSpace(statusSessionID)
+		dashboardOnce = true
+		defer func() {
+			dashboardSessionID = prevSessionID
+			dashboardOnce = prevOnce
+		}()
+		return runDashboardFlow(cmd)
+	},
+}
+
+var feedCmd = &cobra.Command{
+	Use:   "feed",
+	Short: "Live run/task/harness event feed",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		typesFilter := normalizeTypeFilter(feedTypes)
+		if len(typesFilter) == 0 {
+			typesFilter = []string{
+				"task.start",
+				"task.done",
+				"harness.selected",
+				"harness.run.start",
+				"harness.run.complete",
+				"harness.run.error",
+				"harness.usage.reported",
+			}
+		}
+		runIDs, err := resolveTargetRunIDs(cmd.Context(), strings.TrimSpace(feedRunID), strings.TrimSpace(feedSessionID), strings.TrimSpace(feedAgentID))
+		if err != nil {
+			return err
+		}
+		return followEventRuns(cmd, runIDs, true, feedLimit, func(cmd *cobra.Command, runID string, afterSeq int64, limit int) (int64, error) {
+			return printLogsBatch(cmd, runID, typesFilter, strings.TrimSpace(feedHarnessID), afterSeq, limit)
+		})
+	},
+}
+
+var traceCmd = &cobra.Command{
+	Use:   "trace",
+	Short: "Live reasoning/tool/harness trace feed",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		typesFilter := []string{
+			"agent.op.request",
+			"agent.op.response",
+			"model.thinking.summary",
+			"harness.selected",
+			"harness.run.start",
+			"harness.run.complete",
+			"harness.run.error",
+		}
+		runIDs, err := resolveTargetRunIDs(cmd.Context(), strings.TrimSpace(traceRunID), strings.TrimSpace(traceSessionID), strings.TrimSpace(traceAgentID))
+		if err != nil {
+			return err
+		}
+		return followEventRuns(cmd, runIDs, true, traceLimit, func(cmd *cobra.Command, runID string, afterSeq int64, limit int) (int64, error) {
+			return printLogsBatch(cmd, runID, typesFilter, strings.TrimSpace(traceHarnessID), afterSeq, limit)
+		})
+	},
+}
+
+var costsCmd = &cobra.Command{
+	Use:   "costs",
+	Short: "Show session and per-run token/cost totals",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		sessionID := strings.TrimSpace(costsSessionID)
+		if sessionID == "" {
+			projectCtx, err := loadProjectContext()
+			if err == nil && projectCtx.Exists {
+				sessionID = strings.TrimSpace(projectCtx.State.ActiveSessionID)
+			}
+		}
+		if sessionID == "" {
+			return fmt.Errorf("session id is required (use --session-id or initialize project and attach a session)")
+		}
+
+		item, err := rpcFindSession(cmd.Context(), sessionID)
+		if err != nil {
+			return err
+		}
+
+		var totals protocol.SessionGetTotalsResult
+		_ = rpcCall(cmd.Context(), protocol.MethodSessionGetTotals, protocol.SessionGetTotalsParams{
+			ThreadID: protocol.ThreadID(sessionID),
+			TeamID:   strings.TrimSpace(item.TeamID),
+			RunID:    strings.TrimSpace(item.CurrentRunID),
+		}, &totals)
+
+		var runtimeState protocol.RuntimeGetSessionStateResult
+		_ = rpcCall(cmd.Context(), protocol.MethodRuntimeGetSessionState, protocol.RuntimeGetSessionStateParams{
+			SessionID: sessionID,
+		}, &runtimeState)
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Session %s totals: tokens=%d cost=$%.4f\n", sessionID, totals.TotalTokens, totals.TotalCostUSD)
+		w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
+		fmt.Fprintln(w, "RUN\tHARNESS\tSTATUS\tTOKENS\tCOST")
+		for _, rs := range runtimeState.Runs {
+			fmt.Fprintf(
+				w,
+				"%s\t%s\t%s\t%d\t$%.4f\n",
+				blankDash(strings.TrimSpace(rs.RunID)),
+				blankDash(strings.TrimSpace(rs.HarnessID)),
+				blankDash(strings.TrimSpace(rs.EffectiveStatus)),
+				rs.RunTotalTokens,
+				rs.RunTotalCostUSD,
+			)
+		}
+		_ = w.Flush()
+		return nil
+	},
+}
+
+func init() {
+	statusCmd.Flags().StringVar(&statusSessionID, "session-id", "", "session id to inspect (default: active project session)")
+
+	feedCmd.Flags().StringVar(&feedRunID, "run-id", "", "run id to query")
+	feedCmd.Flags().StringVar(&feedSessionID, "session-id", "", "session id scope (defaults to active project session)")
+	feedCmd.Flags().StringVar(&feedAgentID, "agent", "", "agent/run id alias for filtering")
+	feedCmd.Flags().StringVar(&feedHarnessID, "harness-id", "", "filter events by harness id")
+	feedCmd.Flags().StringSliceVar(&feedTypes, "type", nil, "event type filter (repeat or comma-separated)")
+	feedCmd.Flags().IntVar(&feedLimit, "limit", 200, "max events per poll per run")
+
+	traceCmd.Flags().StringVar(&traceRunID, "run-id", "", "run id to query")
+	traceCmd.Flags().StringVar(&traceSessionID, "session-id", "", "session id scope (defaults to active project session)")
+	traceCmd.Flags().StringVar(&traceAgentID, "agent", "", "agent/run id alias for filtering")
+	traceCmd.Flags().StringVar(&traceHarnessID, "harness-id", "", "filter events by harness id")
+	traceCmd.Flags().IntVar(&traceLimit, "limit", 200, "max events per poll per run")
+
+	costsCmd.Flags().StringVar(&costsSessionID, "session-id", "", "session id to inspect (default: active project session)")
+
+	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(feedCmd)
+	rootCmd.AddCommand(traceCmd)
+	rootCmd.AddCommand(costsCmd)
+}

--- a/cmd/agen8/cmd/observe_aliases_test.go
+++ b/cmd/agen8/cmd/observe_aliases_test.go
@@ -1,0 +1,11 @@
+package cmd
+
+import "testing"
+
+func TestObserveAliasCommandsRegistered(t *testing.T) {
+	for _, name := range []string{"status", "feed", "trace", "costs"} {
+		if _, _, err := rootCmd.Find([]string{name}); err != nil {
+			t.Fatalf("expected command %q to be registered: %v", name, err)
+		}
+	}
+}

--- a/cmd/agen8/cmd/tasks.go
+++ b/cmd/agen8/cmd/tasks.go
@@ -106,11 +106,11 @@ var tasksListCmd = &cobra.Command{
 		}
 
 		w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
-		fmt.Fprintln(w, "ID\tSTATUS\tCOST\tTOKENS")
+		fmt.Fprintln(w, "ID\tSTATUS\tHARNESS\tCOST\tTOKENS")
 		for _, t := range tasks {
 			cost := fmt.Sprintf("$%.4f", t.CostUSD)
 			tokens := fmt.Sprintf("%d", t.TotalTokens)
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", t.TaskID, t.Status, cost, tokens)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", t.TaskID, t.Status, blankDash(taskHarnessID(t.Metadata)), cost, tokens)
 		}
 		_ = w.Flush()
 		return nil
@@ -236,7 +236,7 @@ func renderMailWatchOnce(cmd *cobra.Command, sessionID string, view string) erro
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Mail %s for session %s (count=%d)\n", view, sessionID, out.TotalCount)
 	w := tabwriter.NewWriter(os.Stdout, 0, 2, 2, ' ', 0)
-	fmt.Fprintln(w, "ID\tSTATUS\tASSIGNEE\tRUN")
+	fmt.Fprintln(w, "ID\tSTATUS\tHARNESS\tASSIGNEE\tRUN")
 	for _, task := range out.Tasks {
 		assignee := strings.TrimSpace(task.AssignedRole)
 		if assignee == "" {
@@ -244,15 +244,27 @@ func renderMailWatchOnce(cmd *cobra.Command, sessionID string, view string) erro
 		}
 		fmt.Fprintf(
 			w,
-			"%s\t%s\t%s\t%s\n",
+			"%s\t%s\t%s\t%s\t%s\n",
 			blankDash(task.ID),
 			blankDash(task.Status),
+			blankDash(task.HarnessID),
 			blankDash(assignee),
 			blankDash(string(task.RunID)),
 		)
 	}
 	_ = w.Flush()
 	return nil
+}
+
+func taskHarnessID(metadata map[string]any) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	raw, ok := metadata["harnessId"]
+	if !ok || raw == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(raw))
 }
 
 func init() {

--- a/docs/cli-usage.md
+++ b/docs/cli-usage.md
@@ -55,7 +55,11 @@ A typical onboarding workflow:
 | `agen8 coordinator` | Attach to a coordinator-focused chat view and oversee subordinate agents.
 | `agen8 dashboard` | Read-only observability for sessions, runs, tasks, and cost signals.
 | `agen8 monitor` | Observer UI that attaches to a running agent (start the daemon first).
-| `agen8 logs` | Query structured logs and filter by `--agent-id`, `--level`, or `--follow`.
+| `agen8 logs` | Query structured logs and filter by `--run-id`/`--session-id`, `--harness-id`, `--type`, and `--follow`.
+| `agen8 status` | One-shot runtime/dashboard summary (alias of dashboard once mode).
+| `agen8 feed` | Live task/harness event feed.
+| `agen8 trace` | Live tool/reasoning/harness event feed.
+| `agen8 costs` | Session + per-run token/cost summary (errors if RPC fails).
 | `agen8 activity` | Tail the activity stream of proposals and tool calls.
 | `agen8 show session/run/history` | Dump metadata or the JSONL operation log for debugging.
 
@@ -77,6 +81,8 @@ Runtime configuration resolves in this order: CLI flags → environment variable
 | `--include-history-ops` | `AGEN8_INCLUDE_HISTORY_OPS` | Whether operations from `/history` appear in prompts (default: enabled).
 
 For complete flag context and environment-variable guidance, see [docs/cli-usage.md](docs/cli-usage.md) (this document) complemented by [docs/config-toml.md](docs/config-toml.md).
+
+Harness defaults should be set in `${AGEN8_DATA_DIR}/config.toml` under `[harness]` (for example `default_harness = "codex-cli"`). Environment variables remain override-only for ad hoc runs.
 
 ## Troubleshooting CLI sessions
 

--- a/docs/config-toml.md
+++ b/docs/config-toml.md
@@ -30,6 +30,13 @@ model = "z-ai/GLM-5"
 [code_exec]
 # venv_path = ""
 # required_packages = []
+
+[harness]
+# default_harness = "agen8-native" # or "codex-cli"
+# codex_bin = "codex"
+# codex_model = ""
+# codex_profile = ""
+# codex_extra_args = []
 ```
 
 Notes:
@@ -61,6 +68,34 @@ required_packages = ["pandas", "requests", "beautifulsoup4"]
 ```
 
 If an agent run fails due to a missing module, add the package to `required_packages`; the daemon picks it up and reconciles automatically.
+
+## Harness configuration
+
+Use `[harness]` for non-secret orchestrator defaults:
+
+- `harness.default_harness` (string): default adapter ID when task/run do not specify one. Common values: `agen8-native`, `codex-cli`.
+- `harness.codex_bin` (string): path/binary name used for Codex adapter execution.
+- `harness.codex_model` (string): default model passed to `codex exec`.
+- `harness.codex_profile` (string): default Codex profile passed to `codex exec`.
+- `harness.codex_extra_args` ([]string): extra flags passed to `codex exec`.
+
+Example:
+
+```toml
+[harness]
+default_harness = "codex-cli"
+codex_bin = "codex"
+codex_model = "gpt-5"
+codex_profile = "fast"
+codex_extra_args = ["--ephemeral", "--skip-git-repo-check"]
+```
+
+Selection precedence at runtime is:
+
+1. Task-level `harnessId` (RPC `task.create`)
+2. Run-level `run.runtime.harnessId`
+3. `harness.default_harness` from `config.toml`
+4. Fallback: `agen8-native`
 
 ## Resolution order
 

--- a/docs/config.toml.example
+++ b/docs/config.toml.example
@@ -22,3 +22,11 @@ required_packages = ["pandas", "requests"]
 [path_access]
 # allowlist = ["/home/user/shared", "/var/cache/build"]
 # read_only = true   # If true, only reads; if false, reads and writes
+
+# Harness defaults for orchestrating external runtimes.
+[harness]
+# default_harness = "agen8-native"  # or "codex-cli"
+# codex_bin = "codex"
+# codex_model = ""
+# codex_profile = ""
+# codex_extra_args = ["--ephemeral", "--skip-git-repo-check"]

--- a/docs/plans/phase2-external-coordinator-actions.md
+++ b/docs/plans/phase2-external-coordinator-actions.md
@@ -1,0 +1,135 @@
+# Phase 2 Plan: Codex External Orchestration With Dynamic Spawn + Assign
+
+## Summary
+Phase 2 makes `codex-cli` a true orchestrator harness by introducing a strict coordinator action contract that Agen8 validates and applies to its own state.
+
+Locked decisions:
+- Output contract: strict JSON envelope.
+- Apply path: session post-adapter.
+- Orchestration scope: dynamic spawn + assign.
+
+## Scope
+In scope:
+- Parse/validate coordinator actions from external harness output.
+- Apply actions via Agen8 task/run services.
+- Support `create_role_task` and `spawn_worker_task`.
+- Add idempotency + safety limits.
+- Add observability events for parse/apply/reject.
+
+Out of scope:
+- External `task_review` execution (Phase 2.1).
+- New external adapters beyond `codex-cli`.
+
+## Architecture
+### 1) Action contract package
+Add package:
+- `pkg/harness/actions/types.go`
+- `pkg/harness/actions/parse.go`
+- `pkg/harness/actions/validate.go`
+- `pkg/harness/actions/idempotency.go`
+
+Envelope:
+- `version: "agen8.actions.v1"`
+- `mode: "coordinator"`
+- `actions: []`
+
+Action types:
+- `create_role_task`: `{goal, assignedRole, priority?, harnessId?}`
+- `spawn_worker_task`: `{goal, priority?, harnessId?}`
+
+### 2) Session-side apply hook
+File:
+- `pkg/agent/session/session.go`
+
+Add config dependency:
+- `ExternalCoordinatorActionApplier` interface
+
+Flow:
+- For non-native harness + coordinator + action mode enabled:
+  - parse adapter text as strict envelope
+  - validate all actions
+  - apply actions through applier
+  - emit action events
+- If parse/validate/apply fails:
+  - fail current task with explicit reason
+  - no partial duplicate side effects
+
+### 3) App bridge (state mutation owner)
+Add:
+- `internal/app/external_coordinator_bridge.go`
+
+Responsibilities:
+- role validation against team context
+- `task.create` via task manager
+- dynamic child run spawn (deterministic)
+- first-task routing to spawned child run
+- idempotent apply on retries
+
+### 4) Supervisor spawn reuse
+File:
+- `internal/app/daemon_runtime_supervisor.go`
+
+Reuse existing spawn logic (`makeSpawnWorkerFunc`) by exposing deterministic helper:
+- load-or-create child run by deterministic id
+- preserve `ParentRunID`, `SpawnIndex`, runtime model/profile/harness
+
+### 5) Codex coordinator prompt envelope
+Add:
+- `pkg/harness/codexcli/coordinator_envelope.go`
+
+Behavior:
+- wrap coordinator goals with strict “JSON-only output” instructions
+- include valid action schema + limits + valid roles
+- keep non-coordinator external tasks unchanged
+
+### 6) Config additions
+File:
+- `internal/app/runtime_config.go`
+- docs updates in `docs/config-toml.md` and `docs/config.toml.example`
+
+Add optional `[harness]` keys:
+- `codex_action_mode = "disabled" | "coordinator_actions_v1"`
+- `codex_actions_require_json = true|false`
+- `codex_actions_max_actions = <int>`
+- `codex_actions_max_spawn_actions = <int>`
+- `codex_actions_max_goal_chars = <int>`
+
+Default:
+- `codex_action_mode = "disabled"`
+
+## Idempotency and safety
+- deterministic action key from `parentTaskID + actionIndex + normalizedAction`
+- deterministic ids for created tasks/runs from action key
+- if existing id found, treat as already-applied success
+- hard limits from config for action count/spawn count/goal length
+- unknown roles rejected before apply
+
+## Observability
+Emit:
+- `coordinator.actions.parsed`
+- `coordinator.actions.applied`
+- `coordinator.actions.rejected`
+- `coordinator.spawn.created`
+
+Payload includes:
+- `taskId`, `runId`, `harnessId`, `actionCount`, `appliedCount`, `rejectedCount`, `spawnedRunCount`, `reason`
+
+## Tests
+Unit:
+- parser/validator/idempotency determinism in `pkg/harness/actions/*_test.go`
+
+Session:
+- successful apply path
+- malformed envelope failure
+- non-coordinator bypass path
+
+Integration:
+- dynamic spawn creates child run once under retry
+- spawned child receives first task
+- role task creation visible in `task.list`
+- unknown role rejected with no side effects
+
+Regression gates:
+- `task.create`, `task.list`, `logs.query`, `dashboard --once`
+- no implicit bootstrap on clean startup
+- `go test ./...` all green

--- a/internal/app/daemon_runtime_supervisor.go
+++ b/internal/app/daemon_runtime_supervisor.go
@@ -19,6 +19,8 @@ import (
 	"github.com/tinoosan/agen8/pkg/emit"
 	"github.com/tinoosan/agen8/pkg/events"
 	"github.com/tinoosan/agen8/pkg/fsutil"
+	"github.com/tinoosan/agen8/pkg/harness"
+	"github.com/tinoosan/agen8/pkg/harness/codexcli"
 	llmtypes "github.com/tinoosan/agen8/pkg/llm/types"
 	"github.com/tinoosan/agen8/pkg/profile"
 	"github.com/tinoosan/agen8/pkg/prompts"
@@ -47,6 +49,7 @@ type runtimeSupervisorConfig struct {
 	WorkdirAbs       string
 	DefaultProfile   *profile.Profile
 	SoulService      pkgsoul.Service
+	HarnessRegistry  *harness.Registry
 }
 
 type runtimeSupervisor struct {
@@ -63,6 +66,7 @@ type runtimeSupervisor struct {
 	workdirAbs       string
 	defaultProfile   *profile.Profile
 	soulService      pkgsoul.Service
+	harnessRegistry  *harness.Registry
 
 	mu                  sync.Mutex
 	workers             map[string]*managedRuntime
@@ -279,10 +283,34 @@ func (s *runtimeSupervisor) deactivateAndArchiveSubagent(ctx context.Context, ru
 	s.mu.Unlock()
 }
 
+func defaultHarnessRegistryFromEnv() *harness.Registry {
+	reg, err := harness.NewRegistry()
+	if err != nil {
+		log.Printf("daemon: harness registry init failed: %v", err)
+		return nil
+	}
+	codexCfg := codexcli.Config{
+		Binary:           strings.TrimSpace(os.Getenv("AGEN8_CODEX_BIN")),
+		Model:            strings.TrimSpace(os.Getenv("AGEN8_CODEX_MODEL")),
+		Profile:          strings.TrimSpace(os.Getenv("AGEN8_CODEX_PROFILE")),
+		ExtraArgs:        strings.Fields(strings.TrimSpace(os.Getenv("AGEN8_CODEX_EXTRA_ARGS"))),
+		SkipGitRepoCheck: true,
+		Ephemeral:        true,
+	}
+	if err := reg.Register(codexcli.New(codexCfg)); err != nil {
+		log.Printf("daemon: register codex harness adapter failed: %v", err)
+	}
+	return reg
+}
+
 func newRuntimeSupervisor(cfg runtimeSupervisorConfig) *runtimeSupervisor {
 	poll := cfg.PollInterval
 	if poll <= 0 {
 		poll = 1 * time.Second // Faster inbox poll so callbacks and new tasks are picked up sooner
+	}
+	reg := cfg.HarnessRegistry
+	if reg == nil {
+		reg = defaultHarnessRegistryFromEnv()
 	}
 	return &runtimeSupervisor{
 		cfg:              cfg.Cfg,
@@ -298,6 +326,7 @@ func newRuntimeSupervisor(cfg runtimeSupervisorConfig) *runtimeSupervisor {
 		workdirAbs:       cfg.WorkdirAbs,
 		defaultProfile:   cfg.DefaultProfile,
 		soulService:      cfg.SoulService,
+		harnessRegistry:  reg,
 		workers:          map[string]*managedRuntime{},
 	}
 }
@@ -1111,6 +1140,9 @@ func (s *runtimeSupervisor) spawnManagedRun(parent context.Context, sess types.S
 		MaxPending:           50,
 		SessionID:            run.SessionID,
 		RunID:                run.RunID,
+		Workdir:              strings.TrimSpace(s.workdirAbs),
+		RunHarnessID:         strings.TrimSpace(run.Runtime.HarnessID),
+		HarnessRegistry:      s.harnessRegistry,
 		TeamID:               teamID,
 		RoleName:             roleName,
 		IsCoordinator:        isCoordinator,
@@ -1797,12 +1829,15 @@ func (s *runtimeSupervisor) GetRunState(ctx context.Context, sessionID, runID st
 		SessionID:       sessionID,
 		RunID:           runID,
 		Model:           "",
+		HarnessID:       "",
 		PersistedStatus: strings.TrimSpace(run.Status),
 		EffectiveStatus: strings.TrimSpace(run.Status),
 	}
 	if run.Runtime != nil {
 		state.Model = strings.TrimSpace(run.Runtime.Model)
+		state.HarnessID = strings.TrimSpace(run.Runtime.HarnessID)
 	}
+	state.HarnessID = harness.SelectHarnessID(nil, state.HarnessID, os.Getenv)
 	if stats, statsErr := s.taskService.GetRunStats(ctx, runID); statsErr == nil {
 		state.RunTotalTokens = stats.TotalTokens
 		state.RunTotalCostUSD = stats.TotalCost

--- a/internal/app/rpc_runtime_state.go
+++ b/internal/app/rpc_runtime_state.go
@@ -2,8 +2,10 @@ package app
 
 import (
 	"context"
+	"os"
 	"strings"
 
+	"github.com/tinoosan/agen8/pkg/harness"
 	"github.com/tinoosan/agen8/pkg/protocol"
 )
 
@@ -34,10 +36,16 @@ func (s *RPCServer) runtimeGetRunState(ctx context.Context, p protocol.RuntimeGe
 	if err != nil {
 		return protocol.RuntimeGetRunStateResult{}, err
 	}
+	harnessID := ""
+	if run.Runtime != nil {
+		harnessID = strings.TrimSpace(run.Runtime.HarnessID)
+	}
+	harnessID = harness.SelectHarnessID(nil, harnessID, os.Getenv)
 	return protocol.RuntimeGetRunStateResult{
 		State: protocol.RuntimeRunState{
 			SessionID:       sessionID,
 			RunID:           runID,
+			HarnessID:       harnessID,
 			PersistedStatus: strings.TrimSpace(run.Status),
 			EffectiveStatus: strings.TrimSpace(run.Status),
 		},
@@ -70,9 +78,15 @@ func (s *RPCServer) runtimeGetSessionState(ctx context.Context, p protocol.Runti
 			continue
 		}
 		status := strings.TrimSpace(run.Status)
+		harnessID := ""
+		if run.Runtime != nil {
+			harnessID = strings.TrimSpace(run.Runtime.HarnessID)
+		}
+		harnessID = harness.SelectHarnessID(nil, harnessID, os.Getenv)
 		out = append(out, protocol.RuntimeRunState{
 			SessionID:       sessionID,
 			RunID:           rid,
+			HarnessID:       harnessID,
 			PersistedStatus: status,
 			EffectiveStatus: status,
 		})

--- a/internal/app/rpc_session.go
+++ b/internal/app/rpc_session.go
@@ -149,6 +149,17 @@ func parseAssignee(assignee string) (string, string) {
 	return "", assignee
 }
 
+func metadataValueString(metadata map[string]any, key string) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	raw, ok := metadata[key]
+	if !ok || raw == nil {
+		return ""
+	}
+	return strings.TrimSpace(fmt.Sprint(raw))
+}
+
 func protocolTaskFromTypesTask(t types.Task) protocol.Task {
 	return protocol.Task{
 		ID:               strings.TrimSpace(t.TaskID),
@@ -156,6 +167,8 @@ func protocolTaskFromTypesTask(t types.Task) protocol.Task {
 		RunID:            protocol.RunID(strings.TrimSpace(t.RunID)),
 		TeamID:           strings.TrimSpace(t.TeamID),
 		TaskKind:         strings.TrimSpace(t.TaskKind),
+		HarnessID:        metadataValueString(t.Metadata, "harnessId"),
+		HarnessRunRef:    metadataValueString(t.Metadata, "harnessRunRef"),
 		AssignedToType:   strings.TrimSpace(t.AssignedToType),
 		AssignedTo:       strings.TrimSpace(t.AssignedTo),
 		AssignedRole:     strings.TrimSpace(t.AssignedRole),
@@ -1013,6 +1026,9 @@ func (s *RPCServer) taskCreate(ctx context.Context, p protocol.TaskCreateParams)
 		Inputs:         map[string]any{},
 		Metadata:       map[string]any{"source": "rpc.task.create"},
 		CreatedBy:      "monitor",
+	}
+	if harnessID := strings.ToLower(strings.TrimSpace(p.HarnessID)); harnessID != "" {
+		task.Metadata["harnessId"] = harnessID
 	}
 	if task.Priority == 0 {
 		task.Priority = 5

--- a/internal/app/rpc_session_harness_test.go
+++ b/internal/app/rpc_session_harness_test.go
@@ -1,0 +1,91 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/tinoosan/agen8/pkg/agent/state"
+	"github.com/tinoosan/agen8/pkg/config"
+	"github.com/tinoosan/agen8/pkg/fsutil"
+	"github.com/tinoosan/agen8/pkg/protocol"
+	pkgtask "github.com/tinoosan/agen8/pkg/services/task"
+	"github.com/tinoosan/agen8/pkg/store"
+	"github.com/tinoosan/agen8/pkg/types"
+)
+
+func TestRPCServerTaskCreateAndListIncludesHarnessID(t *testing.T) {
+	cfg := config.Config{DataDir: t.TempDir()}
+
+	sess := types.NewSession("goal")
+	run := types.NewRun("goal", 8*1024, sess.SessionID)
+	sess.CurrentRunID = run.RunID
+	sess.Runs = []string{run.RunID}
+	sessStore := store.NewMemorySessionStore()
+	if err := sessStore.SaveSession(context.Background(), sess); err != nil {
+		t.Fatalf("SaveSession: %v", err)
+	}
+	if err := sessStore.SaveRun(context.Background(), run); err != nil {
+		t.Fatalf("SaveRun: %v", err)
+	}
+
+	ts, err := state.NewSQLiteTaskStore(fsutil.GetSQLitePath(cfg.DataDir))
+	if err != nil {
+		t.Fatalf("NewSQLiteTaskStore: %v", err)
+	}
+
+	srv := NewRPCServer(RPCServerConfig{
+		Cfg:         cfg,
+		Run:         run,
+		TaskService: pkgtask.NewManager(ts, nil),
+		Session:     newTestSessionService(cfg, sessStore),
+		Index:       protocol.NewIndex(0, 0),
+	})
+
+	createReq, _ := protocol.NewRequest("1", protocol.MethodTaskCreate, protocol.TaskCreateParams{
+		ThreadID:   protocol.ThreadID(run.SessionID),
+		RunID:      run.RunID,
+		Goal:       "Do harness task",
+		HarnessID:  "codex-cli",
+		AssignedTo: run.RunID,
+	})
+	createResp := rpcRoundTrip(t, srv, createReq)
+	if createResp.Error != nil {
+		t.Fatalf("task.create error: %+v", createResp.Error)
+	}
+	var createRes protocol.TaskCreateResult
+	if err := json.Unmarshal(createResp.Result, &createRes); err != nil {
+		t.Fatalf("unmarshal task.create: %v", err)
+	}
+	if got := createRes.Task.HarnessID; got != "codex-cli" {
+		t.Fatalf("task.create harnessId = %q want %q", got, "codex-cli")
+	}
+
+	stored, err := ts.GetTask(context.Background(), createRes.Task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got := stored.Metadata["harnessId"]; got == nil || got.(string) != "codex-cli" {
+		t.Fatalf("stored task harnessId metadata = %#v", got)
+	}
+
+	listReq, _ := protocol.NewRequest("2", protocol.MethodTaskList, protocol.TaskListParams{
+		ThreadID: protocol.ThreadID(run.SessionID),
+		RunID:    run.RunID,
+		View:     "inbox",
+	})
+	listResp := rpcRoundTrip(t, srv, listReq)
+	if listResp.Error != nil {
+		t.Fatalf("task.list error: %+v", listResp.Error)
+	}
+	var listRes protocol.TaskListResult
+	if err := json.Unmarshal(listResp.Result, &listRes); err != nil {
+		t.Fatalf("unmarshal task.list: %v", err)
+	}
+	if len(listRes.Tasks) == 0 {
+		t.Fatalf("task.list returned no tasks")
+	}
+	if got := listRes.Tasks[0].HarnessID; got != "codex-cli" {
+		t.Fatalf("task.list harnessId = %q want %q", got, "codex-cli")
+	}
+}

--- a/internal/app/runtime_config.go
+++ b/internal/app/runtime_config.go
@@ -22,6 +22,7 @@ type runtimeConfig struct {
 	CodeExec   runtimeConfigCodeExec
 	PathAccess runtimeConfigPathAccess
 	Obsidian   runtimeConfigObsidian
+	Harness    runtimeConfigHarness
 }
 
 type runtimeConfigDefaults struct {
@@ -48,6 +49,14 @@ type runtimeConfigObsidian struct {
 	VaultPath string
 }
 
+type runtimeConfigHarness struct {
+	DefaultHarness string
+	CodexBin       string
+	CodexModel     string
+	CodexProfile   string
+	CodexExtraArgs []string
+}
+
 type runtimeConfigFile struct {
 	Defaults   runtimeConfigDefaultsFile   `toml:"defaults"`
 	Env        map[string]string           `toml:"env"`
@@ -55,6 +64,7 @@ type runtimeConfigFile struct {
 	CodeExec   runtimeConfigCodeExecFile   `toml:"code_exec"`
 	PathAccess runtimeConfigPathAccessFile `toml:"path_access"`
 	Obsidian   runtimeConfigObsidianFile   `toml:"obsidian"`
+	Harness    runtimeConfigHarnessFile    `toml:"harness"`
 }
 
 type runtimeConfigDefaultsFile struct {
@@ -79,6 +89,14 @@ type runtimeConfigPathAccessFile struct {
 
 type runtimeConfigObsidianFile struct {
 	VaultPath string `toml:"vault_path"`
+}
+
+type runtimeConfigHarnessFile struct {
+	DefaultHarness string   `toml:"default_harness"`
+	CodexBin       string   `toml:"codex_bin"`
+	CodexModel     string   `toml:"codex_model"`
+	CodexProfile   string   `toml:"codex_profile"`
+	CodexExtraArgs []string `toml:"codex_extra_args"`
 }
 
 func loadRuntimeConfig(dataDir string) (runtimeConfig, error) {
@@ -159,6 +177,13 @@ model = "`+runtimeDefaultModel+`"
 
 [obsidian]
 # vault_path = ""
+
+[harness]
+# default_harness = "agen8-native" # or "codex-cli"
+# codex_bin = "codex"
+# codex_model = ""
+# codex_profile = ""
+# codex_extra_args = []
 `) + "\n"
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		return "", fmt.Errorf("write %s: %w", path, err)
@@ -202,6 +227,13 @@ func decodeRuntimeConfigFile(path string) (runtimeConfig, bool, error) {
 		},
 		Obsidian: runtimeConfigObsidian{
 			VaultPath: strings.TrimSpace(raw.Obsidian.VaultPath),
+		},
+		Harness: runtimeConfigHarness{
+			DefaultHarness: strings.ToLower(strings.TrimSpace(raw.Harness.DefaultHarness)),
+			CodexBin:       strings.TrimSpace(raw.Harness.CodexBin),
+			CodexModel:     strings.TrimSpace(raw.Harness.CodexModel),
+			CodexProfile:   strings.TrimSpace(raw.Harness.CodexProfile),
+			CodexExtraArgs: normalizeStringList(raw.Harness.CodexExtraArgs),
 		},
 	}
 	for k, v := range raw.Env {
@@ -303,6 +335,21 @@ func mergeRuntimeConfig(base, override runtimeConfig) runtimeConfig {
 	if vaultPath := strings.TrimSpace(override.Obsidian.VaultPath); vaultPath != "" {
 		out.Obsidian.VaultPath = vaultPath
 	}
+	if defaultHarness := strings.ToLower(strings.TrimSpace(override.Harness.DefaultHarness)); defaultHarness != "" {
+		out.Harness.DefaultHarness = defaultHarness
+	}
+	if codexBin := strings.TrimSpace(override.Harness.CodexBin); codexBin != "" {
+		out.Harness.CodexBin = codexBin
+	}
+	if codexModel := strings.TrimSpace(override.Harness.CodexModel); codexModel != "" {
+		out.Harness.CodexModel = codexModel
+	}
+	if codexProfile := strings.TrimSpace(override.Harness.CodexProfile); codexProfile != "" {
+		out.Harness.CodexProfile = codexProfile
+	}
+	if len(override.Harness.CodexExtraArgs) > 0 {
+		out.Harness.CodexExtraArgs = normalizeStringList(override.Harness.CodexExtraArgs)
+	}
 	return out
 }
 
@@ -331,6 +378,11 @@ func applyRuntimeConfigEnvDefaults(cfg runtimeConfig) {
 	setEnvIfUnset("AGEN8_SUBAGENT_MODEL", cfg.Defaults.SubagentModel)
 	setEnvIfUnset("AGEN8_PROFILE", cfg.Defaults.Profile)
 	setEnvIfUnset("OBSIDIAN_VAULT_PATH", cfg.Obsidian.VaultPath)
+	setEnvIfUnset("AGEN8_DEFAULT_HARNESS", cfg.Harness.DefaultHarness)
+	setEnvIfUnset("AGEN8_CODEX_BIN", cfg.Harness.CodexBin)
+	setEnvIfUnset("AGEN8_CODEX_MODEL", cfg.Harness.CodexModel)
+	setEnvIfUnset("AGEN8_CODEX_PROFILE", cfg.Harness.CodexProfile)
+	setEnvIfUnset("AGEN8_CODEX_EXTRA_ARGS", strings.Join(cfg.Harness.CodexExtraArgs, " "))
 	setEnvIfUnset(envSkillsSeedConflict, normalizeSkillsConflict(cfg.Skills.Conflict))
 }
 

--- a/internal/app/runtime_config_test.go
+++ b/internal/app/runtime_config_test.go
@@ -30,6 +30,12 @@ allowlist = ["/home/user/shared", "/var/cache/build"]
 read_only = true
 [obsidian]
 vault_path = "/project/custom-vault"
+[harness]
+default_harness = "codex-cli"
+codex_bin = "/usr/local/bin/codex"
+codex_model = "gpt-5"
+codex_profile = "fast"
+codex_extra_args = ["--skip-git-repo-check", "--ephemeral"]
 `), 0o644); err != nil {
 		t.Fatalf("write dataDir config: %v", err)
 	}
@@ -90,6 +96,21 @@ required_packages = ["requests"]
 	if got := cfg.Obsidian.VaultPath; got != "/project/custom-vault" {
 		t.Fatalf("obsidian.vault_path=%q", got)
 	}
+	if got := cfg.Harness.DefaultHarness; got != "codex-cli" {
+		t.Fatalf("harness.default_harness=%q", got)
+	}
+	if got := cfg.Harness.CodexBin; got != "/usr/local/bin/codex" {
+		t.Fatalf("harness.codex_bin=%q", got)
+	}
+	if got := cfg.Harness.CodexModel; got != "gpt-5" {
+		t.Fatalf("harness.codex_model=%q", got)
+	}
+	if got := cfg.Harness.CodexProfile; got != "fast" {
+		t.Fatalf("harness.codex_profile=%q", got)
+	}
+	if got := strings.Join(cfg.Harness.CodexExtraArgs, ","); got != "--ephemeral,--skip-git-repo-check" {
+		t.Fatalf("harness.codex_extra_args=%q", got)
+	}
 }
 
 func TestApplyRuntimeConfigEnvDefaults_DoesNotOverrideExisting(t *testing.T) {
@@ -107,6 +128,13 @@ func TestApplyRuntimeConfigEnvDefaults_DoesNotOverrideExisting(t *testing.T) {
 		Obsidian: runtimeConfigObsidian{
 			VaultPath: "/knowledge",
 		},
+		Harness: runtimeConfigHarness{
+			DefaultHarness: "codex-cli",
+			CodexBin:       "/usr/local/bin/codex",
+			CodexModel:     "gpt-5",
+			CodexProfile:   "fast",
+			CodexExtraArgs: []string{"--ephemeral"},
+		},
 	}
 	applyRuntimeConfigEnvDefaults(cfg)
 	if got := os.Getenv("OPENROUTER_MODEL"); got != "existing-model" {
@@ -123,6 +151,21 @@ func TestApplyRuntimeConfigEnvDefaults_DoesNotOverrideExisting(t *testing.T) {
 	}
 	if got := os.Getenv("OBSIDIAN_VAULT_PATH"); got != "/knowledge" {
 		t.Fatalf("OBSIDIAN_VAULT_PATH=%q", got)
+	}
+	if got := os.Getenv("AGEN8_DEFAULT_HARNESS"); got != "codex-cli" {
+		t.Fatalf("AGEN8_DEFAULT_HARNESS=%q", got)
+	}
+	if got := os.Getenv("AGEN8_CODEX_BIN"); got != "/usr/local/bin/codex" {
+		t.Fatalf("AGEN8_CODEX_BIN=%q", got)
+	}
+	if got := os.Getenv("AGEN8_CODEX_MODEL"); got != "gpt-5" {
+		t.Fatalf("AGEN8_CODEX_MODEL=%q", got)
+	}
+	if got := os.Getenv("AGEN8_CODEX_PROFILE"); got != "fast" {
+		t.Fatalf("AGEN8_CODEX_PROFILE=%q", got)
+	}
+	if got := os.Getenv("AGEN8_CODEX_EXTRA_ARGS"); got != "--ephemeral" {
+		t.Fatalf("AGEN8_CODEX_EXTRA_ARGS=%q", got)
 	}
 }
 
@@ -151,6 +194,9 @@ func TestEnsureRuntimeConfigTemplate_CreatesDefaultTemplate(t *testing.T) {
 	}
 	if !strings.Contains(text, "[obsidian]") {
 		t.Fatalf("expected obsidian section in template, got:\n%s", text)
+	}
+	if !strings.Contains(text, "[harness]") {
+		t.Fatalf("expected harness section in template, got:\n%s", text)
 	}
 }
 

--- a/pkg/agent/session/harness_test.go
+++ b/pkg/agent/session/harness_test.go
@@ -111,8 +111,8 @@ func TestSessionRunTask_UsesExternalHarnessAdapter(t *testing.T) {
 	if stored.Summary == "" || stored.TotalTokens != 18 {
 		t.Fatalf("unexpected task summary/tokens: summary=%q tokens=%d", stored.Summary, stored.TotalTokens)
 	}
-	if got := stored.CostUSD; got <= 0 {
-		t.Fatalf("expected positive cost from adapter, got %.4f", got)
+	if got := stored.CostUSD; got != 0 {
+		t.Fatalf("expected external harness cost to remain zero, got %.4f", got)
 	}
 	if got := stored.Metadata["harnessId"]; got != "fake-external" {
 		t.Fatalf("metadata harnessId = %#v", got)

--- a/pkg/agent/session/harness_test.go
+++ b/pkg/agent/session/harness_test.go
@@ -1,0 +1,195 @@
+package session
+
+import (
+	"context"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tinoosan/agen8/pkg/agent/state"
+	"github.com/tinoosan/agen8/pkg/harness"
+	"github.com/tinoosan/agen8/pkg/profile"
+	"github.com/tinoosan/agen8/pkg/types"
+)
+
+type testHarnessAdapter struct {
+	id     string
+	result harness.TaskResult
+	err    error
+
+	mu     sync.Mutex
+	calls  int
+	lastRq harness.TaskRequest
+}
+
+func (a *testHarnessAdapter) ID() string { return a.id }
+
+func (a *testHarnessAdapter) RunTask(_ context.Context, req harness.TaskRequest) (harness.TaskResult, error) {
+	a.mu.Lock()
+	a.calls++
+	a.lastRq = req
+	a.mu.Unlock()
+	if a.err != nil {
+		return harness.TaskResult{}, a.err
+	}
+	return a.result, nil
+}
+
+func (a *testHarnessAdapter) called() int {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.calls
+}
+
+func TestSessionRunTask_UsesExternalHarnessAdapter(t *testing.T) {
+	ctx := context.Background()
+	taskStore, _ := state.NewSQLiteTaskStore(filepath.Join(t.TempDir(), "agen8.db"))
+	now := time.Now().UTC()
+
+	adapter := &testHarnessAdapter{
+		id: "fake-external",
+		result: harness.TaskResult{
+			Status:       types.TaskStatusSucceeded,
+			Text:         "external-result",
+			InputTokens:  11,
+			OutputTokens: 7,
+			TotalTokens:  18,
+			CostUSD:      0.0123,
+			AdapterRunID: "external-run-1",
+		},
+	}
+	reg, err := harness.NewRegistry(adapter)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	task := types.Task{
+		TaskID:         "task-1",
+		SessionID:      "sess-1",
+		RunID:          "run-1",
+		AssignedToType: "agent",
+		AssignedTo:     "run-1",
+		TaskKind:       state.TaskKindTask,
+		Goal:           "execute with external harness",
+		Status:         types.TaskStatusPending,
+		CreatedAt:      &now,
+		Metadata:       map[string]any{"harnessId": "fake-external"},
+	}
+	if err := taskStore.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	ag := newFakeAgent()
+	events := &captureEventEmitter{}
+	s, err := New(Config{
+		Agent:           ag,
+		Profile:         &profile.Profile{ID: "general"},
+		TaskStore:       taskStore,
+		Events:          events,
+		SessionID:       "sess-1",
+		RunID:           "run-1",
+		Workdir:         t.TempDir(),
+		HarnessRegistry: reg,
+		PollInterval:    20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := s.drainInbox(ctx); err != nil {
+		t.Fatalf("drainInbox: %v", err)
+	}
+
+	stored, err := taskStore.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stored.Status != types.TaskStatusSucceeded {
+		t.Fatalf("task status = %q want %q", stored.Status, types.TaskStatusSucceeded)
+	}
+	if stored.Summary == "" || stored.TotalTokens != 18 {
+		t.Fatalf("unexpected task summary/tokens: summary=%q tokens=%d", stored.Summary, stored.TotalTokens)
+	}
+	if got := stored.CostUSD; got <= 0 {
+		t.Fatalf("expected positive cost from adapter, got %.4f", got)
+	}
+	if got := stored.Metadata["harnessId"]; got != "fake-external" {
+		t.Fatalf("metadata harnessId = %#v", got)
+	}
+	if got := stored.Metadata["harnessRunRef"]; got != "external-run-1" {
+		t.Fatalf("metadata harnessRunRef = %#v", got)
+	}
+	if calls := adapter.called(); calls != 1 {
+		t.Fatalf("adapter calls = %d want 1", calls)
+	}
+	if runs := ag.runs(); runs != 0 {
+		t.Fatalf("native agent should not run for external harness, got %d runs", runs)
+	}
+	if ev, ok := events.firstByType("harness.run.complete"); !ok {
+		t.Fatalf("expected harness.run.complete event")
+	} else if ev.Data["harnessId"] != "fake-external" {
+		t.Fatalf("harness.run.complete harnessId = %q", ev.Data["harnessId"])
+	}
+}
+
+func TestSessionRunTask_ExternalHarnessFailureMarksTaskFailed(t *testing.T) {
+	ctx := context.Background()
+	taskStore, _ := state.NewSQLiteTaskStore(filepath.Join(t.TempDir(), "agen8.db"))
+	now := time.Now().UTC()
+
+	adapter := &testHarnessAdapter{
+		id: "fake-fail",
+		result: harness.TaskResult{
+			Status: types.TaskStatusFailed,
+			Error:  "adapter failed",
+		},
+	}
+	reg, err := harness.NewRegistry(adapter)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	if err := taskStore.CreateTask(ctx, types.Task{
+		TaskID:         "task-1",
+		SessionID:      "sess-1",
+		RunID:          "run-1",
+		AssignedToType: "agent",
+		AssignedTo:     "run-1",
+		TaskKind:       state.TaskKindTask,
+		Goal:           "should fail",
+		Status:         types.TaskStatusPending,
+		CreatedAt:      &now,
+		Metadata:       map[string]any{"harnessId": "fake-fail"},
+	}); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	s, err := New(Config{
+		Agent:           newFakeAgent(),
+		Profile:         &profile.Profile{ID: "general"},
+		TaskStore:       taskStore,
+		SessionID:       "sess-1",
+		RunID:           "run-1",
+		HarnessRegistry: reg,
+		PollInterval:    20 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if _, err := s.drainInbox(ctx); err != nil {
+		t.Fatalf("drainInbox: %v", err)
+	}
+
+	stored, err := taskStore.GetTask(ctx, "task-1")
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if stored.Status != types.TaskStatusFailed {
+		t.Fatalf("task status = %q want %q", stored.Status, types.TaskStatusFailed)
+	}
+	if stored.Error == "" {
+		t.Fatalf("expected task error to be populated")
+	}
+}

--- a/pkg/agent/session/session.go
+++ b/pkg/agent/session/session.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tinoosan/agen8/pkg/emit"
 	"github.com/tinoosan/agen8/pkg/events"
 	"github.com/tinoosan/agen8/pkg/fsutil"
+	"github.com/tinoosan/agen8/pkg/harness"
 	"github.com/tinoosan/agen8/pkg/llm"
 	llmtypes "github.com/tinoosan/agen8/pkg/llm/types"
 	"github.com/tinoosan/agen8/pkg/profile"
@@ -67,6 +68,10 @@ type Config struct {
 
 	SessionID string
 	RunID     string
+	Workdir   string
+
+	RunHarnessID    string
+	HarnessRegistry *harness.Registry
 
 	TeamID               string
 	RoleName             string
@@ -124,6 +129,8 @@ func New(cfg Config) (*Session, error) {
 	if strings.TrimSpace(cfg.RunID) == "" {
 		return nil, fmt.Errorf("runID is required")
 	}
+	cfg.RunHarnessID = strings.TrimSpace(cfg.RunHarnessID)
+	cfg.Workdir = strings.TrimSpace(cfg.Workdir)
 	if cfg.PollInterval <= 0 {
 		cfg.PollInterval = 2 * time.Second
 	}
@@ -829,174 +836,252 @@ func (s *Session) runTask(ctx context.Context, taskID string, task types.Task) e
 		}
 	}()
 
-	runAgent := s.cfg.Agent
-	if s.cfg.Memory != nil || s.activeProfile != nil {
-		memSnips := []agent.MemorySnippet{}
-		if s.cfg.Memory != nil {
-			if ms, err := s.cfg.Memory.Search(ctx, strings.TrimSpace(task.Goal), s.cfg.MemorySearchLimit); err == nil {
-				memSnips = ms
-			}
-		}
-		aug := buildSystemPrompt(
-			runAgent.GetSystemPrompt(),
-			s.cfg.SoulContent,
-			*s.activeProfile,
-			s.activePromptText,
-			memSnips,
-			s.lastTaskOutcome,
-			s.cfg.TeamID,
-			s.cfg.RoleName,
-			s.cfg.CoordinatorRole,
-			s.cfg.TeamRoles,
-			s.cfg.TeamRoleDescriptions,
-		)
-		if strings.TrimSpace(aug) != "" {
-			cfg := runAgent.Config()
-			cfg.SystemPrompt = aug
-			if cloned, err := runAgent.CloneWithConfig(cfg); err == nil && cloned != nil {
-				runAgent = cloned
-			}
-		}
+	resolvedHarnessID := harness.SelectHarnessID(task.Metadata, s.cfg.RunHarnessID, os.Getenv)
+	if task.Metadata == nil {
+		task.Metadata = map[string]any{}
 	}
+	task.Metadata = harness.SetHarnessIDMetadata(task.Metadata, resolvedHarnessID)
+	_ = s.cfg.TaskStore.UpdateTask(ctx, task)
+	if s.cfg.Events != nil {
+		s.emitBestEffort(ctx, events.Event{
+			Type:    "harness.selected",
+			Message: "Harness selected",
+			Data: map[string]string{
+				"taskId":     taskID,
+				"runId":      strings.TrimSpace(s.cfg.RunID),
+				"harnessId":  resolvedHarnessID,
+				"resolution": "task_metadata|run_runtime|env|fallback",
+			},
+		})
+		s.emitBestEffort(ctx, events.Event{
+			Type:    "harness.run.start",
+			Message: "Harness run started",
+			Data: map[string]string{
+				"taskId":    taskID,
+				"runId":     strings.TrimSpace(s.cfg.RunID),
+				"harnessId": resolvedHarnessID,
+				"taskKind":  taskKind,
+			},
+		})
+	}
+
+	taskCtx := hosttools.WithBatchWaveState(hosttools.WithParentTaskID(ctx, taskID))
+	var runRes agent.RunResult
+	var err error
+	var adapterRunRef string
 
 	var cumulativeInputTokens int
 	var cumulativeOutputTokens int
 	var costInPerM float64
 	var costOutPerM float64
 	var pricingKnown bool
-	{
-		modelID := strings.TrimSpace(runAgent.GetModel())
-		if in, out, ok := cost.LookupPricing(ctx, modelID); ok {
-			costInPerM = in
-			costOutPerM = out
-			pricingKnown = true
-		}
-		cfg := runAgent.Config()
-		orig := cfg.Hooks.OnLLMUsage
-		cfg.Hooks.OnLLMUsage = func(step int, usage llmtypes.LLMUsage) {
-			if orig != nil {
-				orig(step, usage)
-			}
-			cumulativeInputTokens += usage.InputTokens
-			cumulativeOutputTokens += usage.OutputTokens
-			if s.cfg.Events != nil {
-				s.emitBestEffort(ctx, events.Event{
-					Type:    "task.usage",
-					Message: "Task LLM usage",
-					Data: map[string]string{
-						"taskId":       taskID,
-						"step":         fmt.Sprintf("%d", step),
-						"inputTokens":  fmt.Sprintf("%d", usage.InputTokens),
-						"outputTokens": fmt.Sprintf("%d", usage.OutputTokens),
-					},
-				})
-			}
-		}
-		cfg.PromptSource = agent.NewSteeringPromptSource(cfg.PromptSource)
-		if cloned, err := runAgent.CloneWithConfig(cfg); err == nil && cloned != nil {
-			runAgent = cloned
-		}
-	}
+	adapterCostUSD := 0.0
+	nativeHarness := resolvedHarnessID == harness.NativeAdapterID
 
-	taskCtx := hosttools.WithBatchWaveState(hosttools.WithParentTaskID(ctx, taskID))
-	var runRes agent.RunResult
-	var err error
-
-	if s.cfg.RunConversationStore != nil && taskKind == state.TaskKindTask {
-		if s.cfg.Events != nil {
-			s.emitBestEffort(ctx, events.Event{
-				Type:    "run.conversation.active",
-				Message: "Run conversation branch active",
-				Data:    map[string]string{"runId": s.cfg.RunID},
-			})
-		}
-		var msgs []llmtypes.LLMMessage
-		var loadFailed bool
-		msgs, err = s.cfg.RunConversationStore.LoadMessages(taskCtx, s.cfg.RunID)
-		if err != nil {
-			loadFailed = true
-			if s.cfg.Events != nil {
-				s.emitBestEffort(ctx, events.Event{
-					Type:    "run.conversation.load_failed",
-					Message: "Run conversation load failed",
-					Data: map[string]string{
-						"runId": s.cfg.RunID,
-						"error": err.Error(),
-					},
-				})
+	if nativeHarness {
+		runAgent := s.cfg.Agent
+		if s.cfg.Memory != nil || s.activeProfile != nil {
+			memSnips := []agent.MemorySnippet{}
+			if s.cfg.Memory != nil {
+				if ms, searchErr := s.cfg.Memory.Search(ctx, strings.TrimSpace(task.Goal), s.cfg.MemorySearchLimit); searchErr == nil {
+					memSnips = ms
+				}
 			}
-			msgs = nil
+			aug := buildSystemPrompt(
+				runAgent.GetSystemPrompt(),
+				s.cfg.SoulContent,
+				*s.activeProfile,
+				s.activePromptText,
+				memSnips,
+				s.lastTaskOutcome,
+				s.cfg.TeamID,
+				s.cfg.RoleName,
+				s.cfg.CoordinatorRole,
+				s.cfg.TeamRoles,
+				s.cfg.TeamRoleDescriptions,
+			)
+			if strings.TrimSpace(aug) != "" {
+				cfg := runAgent.Config()
+				cfg.SystemPrompt = aug
+				if cloned, cloneErr := runAgent.CloneWithConfig(cfg); cloneErr == nil && cloned != nil {
+					runAgent = cloned
+				}
+			}
 		}
-		loadedCount := len(msgs)
-		if s.cfg.Events != nil {
-			s.emitBestEffort(ctx, events.Event{
-				Type:    "run.conversation.loaded",
-				Message: "Run conversation loaded",
-				Data: map[string]string{
-					"runId":              s.cfg.RunID,
-					"loadedMessageCount": fmt.Sprintf("%d", loadedCount),
-				},
-			})
-		}
-		msgs = append(msgs, llmtypes.LLMMessage{
-			Role:    "user",
-			Content: strings.TrimSpace(task.Goal),
-		})
 
-		var updatedMsgs []llmtypes.LLMMessage
-		runRes, updatedMsgs, _, err = runAgent.RunConversation(taskCtx, msgs)
-		if err == nil && !loadFailed {
-			if saveErr := s.cfg.RunConversationStore.SaveMessages(taskCtx, s.cfg.RunID, updatedMsgs); saveErr != nil {
+		{
+			modelID := strings.TrimSpace(runAgent.GetModel())
+			if in, out, ok := cost.LookupPricing(ctx, modelID); ok {
+				costInPerM = in
+				costOutPerM = out
+				pricingKnown = true
+			}
+			cfg := runAgent.Config()
+			orig := cfg.Hooks.OnLLMUsage
+			cfg.Hooks.OnLLMUsage = func(step int, usage llmtypes.LLMUsage) {
+				if orig != nil {
+					orig(step, usage)
+				}
+				cumulativeInputTokens += usage.InputTokens
+				cumulativeOutputTokens += usage.OutputTokens
 				if s.cfg.Events != nil {
 					s.emitBestEffort(ctx, events.Event{
-						Type:    "run.conversation.save_failed",
-						Message: "Run conversation save failed",
+						Type:    "task.usage",
+						Message: "Task LLM usage",
 						Data: map[string]string{
-							"runId": s.cfg.RunID,
-							"error": saveErr.Error(),
+							"taskId":       taskID,
+							"step":         fmt.Sprintf("%d", step),
+							"inputTokens":  fmt.Sprintf("%d", usage.InputTokens),
+							"outputTokens": fmt.Sprintf("%d", usage.OutputTokens),
 						},
 					})
 				}
-			} else if s.cfg.Events != nil {
-				s.emitBestEffort(ctx, events.Event{
-					Type:    "run.conversation.saved",
-					Message: "Run conversation saved",
-					Data: map[string]string{
-						"runId":             s.cfg.RunID,
-						"savedMessageCount": fmt.Sprintf("%d", len(updatedMsgs)),
-					},
-				})
 			}
-		} else if err == nil && loadFailed {
+			cfg.PromptSource = agent.NewSteeringPromptSource(cfg.PromptSource)
+			if cloned, cloneErr := runAgent.CloneWithConfig(cfg); cloneErr == nil && cloned != nil {
+				runAgent = cloned
+			}
+		}
+
+		if s.cfg.RunConversationStore != nil && taskKind == state.TaskKindTask {
 			if s.cfg.Events != nil {
 				s.emitBestEffort(ctx, events.Event{
-					Type:    "run.conversation.save_skipped",
-					Message: "Run conversation save skipped due to prior load failure",
+					Type:    "run.conversation.active",
+					Message: "Run conversation branch active",
+					Data:    map[string]string{"runId": s.cfg.RunID},
+				})
+			}
+			var msgs []llmtypes.LLMMessage
+			var loadFailed bool
+			msgs, err = s.cfg.RunConversationStore.LoadMessages(taskCtx, s.cfg.RunID)
+			if err != nil {
+				loadFailed = true
+				if s.cfg.Events != nil {
+					s.emitBestEffort(ctx, events.Event{
+						Type:    "run.conversation.load_failed",
+						Message: "Run conversation load failed",
+						Data: map[string]string{
+							"runId": s.cfg.RunID,
+							"error": err.Error(),
+						},
+					})
+				}
+				msgs = nil
+			}
+			loadedCount := len(msgs)
+			if s.cfg.Events != nil {
+				s.emitBestEffort(ctx, events.Event{
+					Type:    "run.conversation.loaded",
+					Message: "Run conversation loaded",
 					Data: map[string]string{
-						"runId": s.cfg.RunID,
+						"runId":              s.cfg.RunID,
+						"loadedMessageCount": fmt.Sprintf("%d", loadedCount),
 					},
 				})
 			}
+			msgs = append(msgs, llmtypes.LLMMessage{
+				Role:    "user",
+				Content: strings.TrimSpace(task.Goal),
+			})
+
+			var updatedMsgs []llmtypes.LLMMessage
+			runRes, updatedMsgs, _, err = runAgent.RunConversation(taskCtx, msgs)
+			if err == nil && !loadFailed {
+				if saveErr := s.cfg.RunConversationStore.SaveMessages(taskCtx, s.cfg.RunID, updatedMsgs); saveErr != nil {
+					if s.cfg.Events != nil {
+						s.emitBestEffort(ctx, events.Event{
+							Type:    "run.conversation.save_failed",
+							Message: "Run conversation save failed",
+							Data: map[string]string{
+								"runId": s.cfg.RunID,
+								"error": saveErr.Error(),
+							},
+						})
+					}
+				} else if s.cfg.Events != nil {
+					s.emitBestEffort(ctx, events.Event{
+						Type:    "run.conversation.saved",
+						Message: "Run conversation saved",
+						Data: map[string]string{
+							"runId":             s.cfg.RunID,
+							"savedMessageCount": fmt.Sprintf("%d", len(updatedMsgs)),
+						},
+					})
+				}
+			} else if err == nil && loadFailed {
+				if s.cfg.Events != nil {
+					s.emitBestEffort(ctx, events.Event{
+						Type:    "run.conversation.save_skipped",
+						Message: "Run conversation save skipped due to prior load failure",
+						Data: map[string]string{
+							"runId": s.cfg.RunID,
+						},
+					})
+				}
+			}
+		} else {
+			if s.cfg.Events != nil {
+				reason := "store_nil"
+				if s.cfg.RunConversationStore != nil {
+					reason = "task_kind"
+				}
+				s.emitBestEffort(ctx, events.Event{
+					Type:    "run.conversation.skipped",
+					Message: "Run conversation branch skipped",
+					Data:    map[string]string{"runId": s.cfg.RunID, "reason": reason, "taskKind": taskKind},
+				})
+			}
+			runRes, err = runAgent.Run(taskCtx, strings.TrimSpace(task.Goal))
 		}
 	} else {
-		if s.cfg.Events != nil {
-			reason := "store_nil"
-			if s.cfg.RunConversationStore != nil {
-				reason = "task_kind"
+		reg := s.cfg.HarnessRegistry
+		if reg == nil {
+			err = fmt.Errorf("harness adapter %q unavailable (registry not configured)", resolvedHarnessID)
+		} else {
+			adapter, ok := reg.Get(resolvedHarnessID)
+			if !ok || adapter == nil {
+				err = fmt.Errorf("harness adapter %q is not registered", resolvedHarnessID)
+			} else {
+				reqMeta := map[string]any{}
+				for k, v := range task.Metadata {
+					reqMeta[k] = v
+				}
+				adaptRes, runErr := adapter.RunTask(taskCtx, harness.TaskRequest{
+					TaskID:    strings.TrimSpace(taskID),
+					RunID:     strings.TrimSpace(s.cfg.RunID),
+					SessionID: strings.TrimSpace(s.cfg.SessionID),
+					Goal:      strings.TrimSpace(task.Goal),
+					TaskKind:  taskKind,
+					Metadata:  reqMeta,
+					Workdir:   strings.TrimSpace(s.cfg.Workdir),
+				})
+				if runErr != nil {
+					err = runErr
+				} else {
+					adaptRes = harness.NormalizeResult(adaptRes)
+					adapterRunRef = strings.TrimSpace(adaptRes.AdapterRunID)
+					adapterCostUSD = adaptRes.CostUSD
+					cumulativeInputTokens = adaptRes.InputTokens
+					cumulativeOutputTokens = adaptRes.OutputTokens
+					runRes = agent.RunResult{
+						Text:      strings.TrimSpace(adaptRes.Text),
+						Artifacts: append([]string(nil), adaptRes.Artifacts...),
+						Status:    adaptRes.Status,
+						Error:     strings.TrimSpace(adaptRes.Error),
+					}
+				}
 			}
-			s.emitBestEffort(ctx, events.Event{
-				Type:    "run.conversation.skipped",
-				Message: "Run conversation branch skipped",
-				Data:    map[string]string{"runId": s.cfg.RunID, "reason": reason, "taskKind": taskKind},
-			})
 		}
-		runRes, err = runAgent.Run(taskCtx, strings.TrimSpace(task.Goal))
+	}
+	if adapterRunRef != "" {
+		task.Metadata["harnessRunRef"] = adapterRunRef
+		_ = s.cfg.TaskStore.UpdateTask(ctx, task)
 	}
 
 	doneAt := time.Now()
 	totalTokens := cumulativeInputTokens + cumulativeOutputTokens
-	costUSD := 0.0
-	if pricingKnown {
+	costUSD := adapterCostUSD
+	if nativeHarness && pricingKnown {
 		costUSD = (float64(cumulativeInputTokens)/1_000_000.0)*costInPerM + (float64(cumulativeOutputTokens)/1_000_000.0)*costOutPerM
 	}
 	tr := types.TaskResult{
@@ -1016,38 +1101,40 @@ func (s *Session) runTask(ctx context.Context, taskID string, task types.Task) e
 		} else {
 			tr.Status = types.TaskStatusFailed
 			tr.Error = err.Error()
-			var repeatedInvalidErr *agent.RepeatedInvalidToolCallError
-			if errors.As(err, &repeatedInvalidErr) {
-				payload := map[string]string{
-					"taskId":             taskID,
-					"tool":               strings.TrimSpace(repeatedInvalidErr.ToolName),
-					"reason":             strings.TrimSpace(repeatedInvalidErr.LastError),
-					"consecutiveInvalid": fmt.Sprintf("%d", repeatedInvalidErr.Count),
-					"elapsedSeconds":     fmt.Sprintf("%d", int(repeatedInvalidErr.Elapsed.Round(time.Second).Seconds())),
+			if nativeHarness {
+				var repeatedInvalidErr *agent.RepeatedInvalidToolCallError
+				if errors.As(err, &repeatedInvalidErr) {
+					payload := map[string]string{
+						"taskId":             taskID,
+						"tool":               strings.TrimSpace(repeatedInvalidErr.ToolName),
+						"reason":             strings.TrimSpace(repeatedInvalidErr.LastError),
+						"consecutiveInvalid": fmt.Sprintf("%d", repeatedInvalidErr.Count),
+						"elapsedSeconds":     fmt.Sprintf("%d", int(repeatedInvalidErr.Elapsed.Round(time.Second).Seconds())),
+					}
+					s.emitBestEffort(ctx, events.Event{
+						Type:    "task.tool.invalid_repeated",
+						Message: "Task failed due to repeated invalid tool calls",
+						Data:    payload,
+					})
 				}
-				s.emitBestEffort(ctx, events.Event{
-					Type:    "task.tool.invalid_repeated",
-					Message: "Task failed due to repeated invalid tool calls",
-					Data:    payload,
-				})
-			}
-			if s.cfg.Events != nil {
-				errInfo := llm.ClassifyError(err)
-				payload := map[string]string{
-					"taskId":     taskID,
-					"class":      fallback(strings.TrimSpace(errInfo.Class), "unknown"),
-					"retryable":  fmt.Sprintf("%t", errInfo.Retryable),
-					"statusCode": fmt.Sprintf("%d", errInfo.StatusCode),
-					"message":    fallback(strings.TrimSpace(errInfo.Message), strings.TrimSpace(err.Error())),
+				if s.cfg.Events != nil {
+					errInfo := llm.ClassifyError(err)
+					payload := map[string]string{
+						"taskId":     taskID,
+						"class":      fallback(strings.TrimSpace(errInfo.Class), "unknown"),
+						"retryable":  fmt.Sprintf("%t", errInfo.Retryable),
+						"statusCode": fmt.Sprintf("%d", errInfo.StatusCode),
+						"message":    fallback(strings.TrimSpace(errInfo.Message), strings.TrimSpace(err.Error())),
+					}
+					if code := strings.TrimSpace(errInfo.Code); code != "" {
+						payload["code"] = code
+					}
+					s.emitBestEffort(ctx, events.Event{
+						Type:    "llm.error",
+						Message: llmErrorMessage(errInfo),
+						Data:    payload,
+					})
 				}
-				if code := strings.TrimSpace(errInfo.Code); code != "" {
-					payload["code"] = code
-				}
-				s.emitBestEffort(ctx, events.Event{
-					Type:    "llm.error",
-					Message: llmErrorMessage(errInfo),
-					Data:    payload,
-				})
 			}
 		}
 	} else {
@@ -1120,10 +1207,14 @@ func (s *Session) runTask(ctx context.Context, taskID string, task types.Task) e
 	// Emit completion events before updating task state (ordering).
 	if s.cfg.Events != nil {
 		data := map[string]string{
-			"taskId":   taskID,
-			"status":   string(tr.Status),
-			"profile":  s.activeProfile.ID,
-			"taskKind": taskKind,
+			"taskId":    taskID,
+			"status":    string(tr.Status),
+			"profile":   s.activeProfile.ID,
+			"taskKind":  taskKind,
+			"harnessId": resolvedHarnessID,
+		}
+		if adapterRunRef != "" {
+			data["harnessRunRef"] = adapterRunRef
 		}
 		if taskSource != "" {
 			data["source"] = taskSource
@@ -1156,6 +1247,36 @@ func (s *Session) runTask(ctx context.Context, taskID string, task types.Task) e
 			// Always include the first artifact path (typically SUMMARY.md).
 			data["artifact0"] = tr.Artifacts[0]
 		}
+		if tr.TotalTokens > 0 || tr.CostUSD > 0 {
+			usageData := map[string]string{
+				"taskId":       taskID,
+				"runId":        strings.TrimSpace(s.cfg.RunID),
+				"harnessId":    resolvedHarnessID,
+				"inputTokens":  fmt.Sprintf("%d", tr.InputTokens),
+				"outputTokens": fmt.Sprintf("%d", tr.OutputTokens),
+				"totalTokens":  fmt.Sprintf("%d", tr.TotalTokens),
+				"costUSD":      fmt.Sprintf("%.4f", tr.CostUSD),
+			}
+			if adapterRunRef != "" {
+				usageData["harnessRunRef"] = adapterRunRef
+			}
+			s.emitBestEffort(ctx, events.Event{
+				Type:    "harness.usage.reported",
+				Message: "Harness usage recorded",
+				Data:    usageData,
+			})
+		}
+		harnessEventType := "harness.run.complete"
+		harnessEventMsg := "Harness run completed"
+		if tr.Status == types.TaskStatusFailed {
+			harnessEventType = "harness.run.error"
+			harnessEventMsg = "Harness run failed"
+		}
+		s.emitBestEffort(ctx, events.Event{
+			Type:    harnessEventType,
+			Message: harnessEventMsg,
+			Data:    data,
+		})
 		s.emitBestEffort(ctx, events.Event{Type: "task.done", Message: "Task finished", Data: data})
 		if strings.EqualFold(taskSource, "heartbeat") {
 			s.emitBestEffort(ctx, events.Event{

--- a/pkg/agent/session/session.go
+++ b/pkg/agent/session/session.go
@@ -876,7 +876,6 @@ func (s *Session) runTask(ctx context.Context, taskID string, task types.Task) e
 	var costInPerM float64
 	var costOutPerM float64
 	var pricingKnown bool
-	adapterCostUSD := 0.0
 	nativeHarness := resolvedHarnessID == harness.NativeAdapterID
 
 	if nativeHarness {
@@ -1061,7 +1060,6 @@ func (s *Session) runTask(ctx context.Context, taskID string, task types.Task) e
 				} else {
 					adaptRes = harness.NormalizeResult(adaptRes)
 					adapterRunRef = strings.TrimSpace(adaptRes.AdapterRunID)
-					adapterCostUSD = adaptRes.CostUSD
 					cumulativeInputTokens = adaptRes.InputTokens
 					cumulativeOutputTokens = adaptRes.OutputTokens
 					cumulativeTotalTokens = adaptRes.TotalTokens
@@ -1085,7 +1083,7 @@ func (s *Session) runTask(ctx context.Context, taskID string, task types.Task) e
 	if !nativeHarness && cumulativeTotalTokens > 0 {
 		totalTokens = cumulativeTotalTokens
 	}
-	costUSD := adapterCostUSD
+	costUSD := 0.0
 	if nativeHarness && pricingKnown {
 		costUSD = (float64(cumulativeInputTokens)/1_000_000.0)*costInPerM + (float64(cumulativeOutputTokens)/1_000_000.0)*costOutPerM
 	}
@@ -1260,7 +1258,9 @@ func (s *Session) runTask(ctx context.Context, taskID string, task types.Task) e
 				"inputTokens":  fmt.Sprintf("%d", tr.InputTokens),
 				"outputTokens": fmt.Sprintf("%d", tr.OutputTokens),
 				"totalTokens":  fmt.Sprintf("%d", tr.TotalTokens),
-				"costUSD":      fmt.Sprintf("%.4f", tr.CostUSD),
+			}
+			if nativeHarness && tr.CostUSD > 0 {
+				usageData["costUSD"] = fmt.Sprintf("%.4f", tr.CostUSD)
 			}
 			if adapterRunRef != "" {
 				usageData["harnessRunRef"] = adapterRunRef

--- a/pkg/agent/session/session.go
+++ b/pkg/agent/session/session.go
@@ -872,6 +872,7 @@ func (s *Session) runTask(ctx context.Context, taskID string, task types.Task) e
 
 	var cumulativeInputTokens int
 	var cumulativeOutputTokens int
+	var cumulativeTotalTokens int
 	var costInPerM float64
 	var costOutPerM float64
 	var pricingKnown bool
@@ -1063,6 +1064,7 @@ func (s *Session) runTask(ctx context.Context, taskID string, task types.Task) e
 					adapterCostUSD = adaptRes.CostUSD
 					cumulativeInputTokens = adaptRes.InputTokens
 					cumulativeOutputTokens = adaptRes.OutputTokens
+					cumulativeTotalTokens = adaptRes.TotalTokens
 					runRes = agent.RunResult{
 						Text:      strings.TrimSpace(adaptRes.Text),
 						Artifacts: append([]string(nil), adaptRes.Artifacts...),
@@ -1080,6 +1082,9 @@ func (s *Session) runTask(ctx context.Context, taskID string, task types.Task) e
 
 	doneAt := time.Now()
 	totalTokens := cumulativeInputTokens + cumulativeOutputTokens
+	if !nativeHarness && cumulativeTotalTokens > 0 {
+		totalTokens = cumulativeTotalTokens
+	}
 	costUSD := adapterCostUSD
 	if nativeHarness && pricingKnown {
 		costUSD = (float64(cumulativeInputTokens)/1_000_000.0)*costInPerM + (float64(cumulativeOutputTokens)/1_000_000.0)*costOutPerM

--- a/pkg/agent/state/sqlite_task_store.go
+++ b/pkg/agent/state/sqlite_task_store.go
@@ -908,7 +908,8 @@ func (s *SQLiteTaskStore) ListTasks(ctx context.Context, filter TaskFilter) ([]t
 			COALESCE(summary, ''), COALESCE(error, ''),
 			attempts, COALESCE(lease_until, ''),
 			input_tokens, output_tokens, total_tokens, cost_usd,
-			duration_seconds, updated_at
+			duration_seconds, updated_at,
+			COALESCE(metadata_json, '{}')
 		FROM tasks
 		WHERE 1=1
 	`
@@ -1011,6 +1012,7 @@ func (s *SQLiteTaskStore) ListTasks(ctx context.Context, filter TaskFilter) ([]t
 		var finishedRaw string
 		var leaseRaw string
 		var updatedRaw string
+		var metadataRaw string
 		if err := rows.Scan(
 			&t.TaskID, &t.SessionID, &t.RunID, &t.TeamID, &t.AssignedRole, &t.AssignedToType, &t.AssignedTo, &t.ClaimedByAgentID, &t.RoleSnapshot, &t.TaskKind, &t.CreatedBy, &t.Goal,
 			&t.Priority, &status, &createdRaw,
@@ -1018,7 +1020,7 @@ func (s *SQLiteTaskStore) ListTasks(ctx context.Context, filter TaskFilter) ([]t
 			&t.Summary, &t.Error,
 			&t.Attempts, &leaseRaw,
 			&t.InputTokens, &t.OutputTokens, &t.TotalTokens, &t.CostUSD,
-			&t.DurationSeconds, &updatedRaw,
+			&t.DurationSeconds, &updatedRaw, &metadataRaw,
 		); err != nil {
 			return nil, err
 		}
@@ -1037,6 +1039,9 @@ func (s *SQLiteTaskStore) ListTasks(ctx context.Context, filter TaskFilter) ([]t
 		}
 		if tt := parseTime(leaseRaw); !tt.IsZero() {
 			t.LeaseUntil = &tt
+		}
+		if strings.TrimSpace(metadataRaw) != "" {
+			_ = json.Unmarshal([]byte(metadataRaw), &t.Metadata)
 		}
 		out = append(out, t)
 	}

--- a/pkg/harness/adapter.go
+++ b/pkg/harness/adapter.go
@@ -1,0 +1,65 @@
+package harness
+
+import (
+	"context"
+	"strings"
+
+	"github.com/tinoosan/agen8/pkg/types"
+)
+
+const (
+	// NativeAdapterID identifies the built-in agen8 task runner.
+	NativeAdapterID = "agen8-native"
+	// DefaultHarnessEnvVar controls the process-wide default harness selection.
+	DefaultHarnessEnvVar = "AGEN8_DEFAULT_HARNESS"
+)
+
+// TaskRequest is the adapter-level unit of work.
+type TaskRequest struct {
+	TaskID    string
+	RunID     string
+	SessionID string
+	Goal      string
+	TaskKind  string
+	Metadata  map[string]any
+	Workdir   string
+}
+
+// TaskResult is the adapter-level execution result.
+type TaskResult struct {
+	Status       types.TaskStatus
+	Text         string
+	Error        string
+	Artifacts    []string
+	InputTokens  int
+	OutputTokens int
+	TotalTokens  int
+	CostUSD      float64
+	AdapterRunID string
+}
+
+// Adapter executes a task for a specific harness implementation.
+type Adapter interface {
+	ID() string
+	RunTask(ctx context.Context, req TaskRequest) (TaskResult, error)
+}
+
+// NormalizeResult ensures task result invariants that callers rely on.
+func NormalizeResult(in TaskResult) TaskResult {
+	out := in
+	if out.TotalTokens <= 0 {
+		out.TotalTokens = out.InputTokens + out.OutputTokens
+	}
+	status := types.TaskStatus(strings.ToLower(strings.TrimSpace(string(out.Status))))
+	switch status {
+	case types.TaskStatusSucceeded, types.TaskStatusFailed, types.TaskStatusCanceled:
+		out.Status = status
+	default:
+		if strings.TrimSpace(out.Error) != "" {
+			out.Status = types.TaskStatusFailed
+		} else {
+			out.Status = types.TaskStatusSucceeded
+		}
+	}
+	return out
+}

--- a/pkg/harness/codexcli/adapter.go
+++ b/pkg/harness/codexcli/adapter.go
@@ -1,0 +1,291 @@
+package codexcli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/tinoosan/agen8/pkg/harness"
+	"github.com/tinoosan/agen8/pkg/types"
+)
+
+const AdapterID = "codex-cli"
+
+// Config controls codex exec invocation.
+type Config struct {
+	Binary           string
+	Model            string
+	Profile          string
+	ExtraArgs        []string
+	SkipGitRepoCheck bool
+	Ephemeral        bool
+}
+
+type Adapter struct {
+	cfg Config
+}
+
+func New(cfg Config) *Adapter {
+	if strings.TrimSpace(cfg.Binary) == "" {
+		cfg.Binary = "codex"
+	}
+	if !cfg.SkipGitRepoCheck {
+		cfg.SkipGitRepoCheck = true
+	}
+	if !cfg.Ephemeral {
+		cfg.Ephemeral = true
+	}
+	return &Adapter{cfg: cfg}
+}
+
+func (a *Adapter) ID() string { return AdapterID }
+
+func (a *Adapter) RunTask(ctx context.Context, req harness.TaskRequest) (harness.TaskResult, error) {
+	if a == nil {
+		return harness.TaskResult{}, fmt.Errorf("codex adapter is nil")
+	}
+	goal := strings.TrimSpace(req.Goal)
+	if goal == "" {
+		return harness.TaskResult{}, fmt.Errorf("task goal is required")
+	}
+
+	lastMsgFile, err := os.CreateTemp("", "agen8-codex-last-message-*.txt")
+	if err != nil {
+		return harness.TaskResult{}, err
+	}
+	lastMsgPath := lastMsgFile.Name()
+	_ = lastMsgFile.Close()
+	defer os.Remove(lastMsgPath)
+
+	args := []string{"exec", "--json", "--output-last-message", lastMsgPath}
+	if a.cfg.SkipGitRepoCheck {
+		args = append(args, "--skip-git-repo-check")
+	}
+	if a.cfg.Ephemeral {
+		args = append(args, "--ephemeral")
+	}
+	if v := strings.TrimSpace(a.cfg.Model); v != "" {
+		args = append(args, "--model", v)
+	}
+	if v := strings.TrimSpace(a.cfg.Profile); v != "" {
+		args = append(args, "--profile", v)
+	}
+	workdir := strings.TrimSpace(req.Workdir)
+	if workdir != "" {
+		args = append(args, "--cd", workdir)
+	}
+	for _, extra := range a.cfg.ExtraArgs {
+		extra = strings.TrimSpace(extra)
+		if extra == "" {
+			continue
+		}
+		args = append(args, extra)
+	}
+	args = append(args, goal)
+
+	cmd := exec.CommandContext(ctx, strings.TrimSpace(a.cfg.Binary), args...)
+	if workdir != "" {
+		cmd.Dir = workdir
+	}
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+
+	usage := parseUsage(stdout.Bytes())
+	message := readTrimmedFile(lastMsgPath)
+	if message == "" {
+		message = strings.TrimSpace(stdout.String())
+	}
+	if message == "" {
+		message = strings.TrimSpace(stderr.String())
+	}
+
+	result := harness.NormalizeResult(harness.TaskResult{
+		Status:       types.TaskStatusSucceeded,
+		Text:         message,
+		InputTokens:  usage.inputTokens,
+		OutputTokens: usage.outputTokens,
+		TotalTokens:  usage.totalTokens,
+		CostUSD:      usage.costUSD,
+		AdapterRunID: usage.runRef,
+	})
+
+	if err == nil {
+		return result, nil
+	}
+	if errors.Is(ctx.Err(), context.Canceled) {
+		result.Status = types.TaskStatusCanceled
+		if strings.TrimSpace(result.Error) == "" {
+			result.Error = "stopped by user"
+		}
+		return result, nil
+	}
+	result.Status = types.TaskStatusFailed
+	if strings.TrimSpace(result.Error) == "" {
+		result.Error = strings.TrimSpace(stderr.String())
+	}
+	if strings.TrimSpace(result.Error) == "" {
+		result.Error = err.Error()
+	}
+	return result, nil
+}
+
+type usageParse struct {
+	inputTokens  int
+	outputTokens int
+	totalTokens  int
+	costUSD      float64
+	runRef       string
+}
+
+func parseUsage(raw []byte) usageParse {
+	var out usageParse
+	scanner := bufio.NewScanner(bytes.NewReader(raw))
+	scanner.Buffer(make([]byte, 0, 64*1024), 2*1024*1024)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(line), &payload); err != nil {
+			continue
+		}
+		if out.runRef == "" {
+			out.runRef = firstString(payload, "run_id", "runId", "session_id", "sessionId", "id")
+		}
+		if n, ok := maxNumber(payload, "input_tokens", "inputTokens", "prompt_tokens", "promptTokens"); ok && int(n) > out.inputTokens {
+			out.inputTokens = int(n)
+		}
+		if n, ok := maxNumber(payload, "output_tokens", "outputTokens", "completion_tokens", "completionTokens"); ok && int(n) > out.outputTokens {
+			out.outputTokens = int(n)
+		}
+		if n, ok := maxNumber(payload, "total_tokens", "totalTokens"); ok && int(n) > out.totalTokens {
+			out.totalTokens = int(n)
+		}
+		if n, ok := maxNumber(payload, "cost_usd", "costUSD", "total_cost_usd", "totalCostUSD"); ok && n > out.costUSD {
+			out.costUSD = n
+		}
+	}
+	if out.totalTokens <= 0 {
+		out.totalTokens = out.inputTokens + out.outputTokens
+	}
+	return out
+}
+
+func maxNumber(v any, keys ...string) (float64, bool) {
+	keySet := map[string]struct{}{}
+	for _, k := range keys {
+		keySet[strings.ToLower(strings.TrimSpace(k))] = struct{}{}
+	}
+	return findNumber(v, keySet)
+}
+
+func findNumber(v any, keys map[string]struct{}) (float64, bool) {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, value := range t {
+			if _, ok := keys[strings.ToLower(strings.TrimSpace(k))]; ok {
+				if n, ok := asFloat(value); ok {
+					return n, true
+				}
+			}
+			if n, ok := findNumber(value, keys); ok {
+				return n, true
+			}
+		}
+	case []any:
+		for _, item := range t {
+			if n, ok := findNumber(item, keys); ok {
+				return n, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func firstString(v any, keys ...string) string {
+	keySet := map[string]struct{}{}
+	for _, k := range keys {
+		keySet[strings.ToLower(strings.TrimSpace(k))] = struct{}{}
+	}
+	return findString(v, keySet)
+}
+
+func findString(v any, keys map[string]struct{}) string {
+	switch t := v.(type) {
+	case map[string]any:
+		for k, value := range t {
+			if _, ok := keys[strings.ToLower(strings.TrimSpace(k))]; ok {
+				if s := strings.TrimSpace(fmt.Sprint(value)); s != "" {
+					return s
+				}
+			}
+			if s := findString(value, keys); s != "" {
+				return s
+			}
+		}
+	case []any:
+		for _, item := range t {
+			if s := findString(item, keys); s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+func asFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case json.Number:
+		f, err := n.Float64()
+		return f, err == nil
+	case string:
+		n = strings.TrimSpace(n)
+		if n == "" {
+			return 0, false
+		}
+		f, err := json.Number(n).Float64()
+		return f, err == nil
+	default:
+		return 0, false
+	}
+}
+
+func readTrimmedFile(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	abs := path
+	if !filepath.IsAbs(abs) {
+		if resolved, err := filepath.Abs(abs); err == nil {
+			abs = resolved
+		}
+	}
+	data, err := os.ReadFile(abs)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}

--- a/pkg/harness/native_adapter.go
+++ b/pkg/harness/native_adapter.go
@@ -1,0 +1,31 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+)
+
+// RunTaskFunc executes a task using the native agen8 runner.
+type RunTaskFunc func(ctx context.Context, req TaskRequest) (TaskResult, error)
+
+// NativeAdapter delegates to a caller-provided native task runner implementation.
+type NativeAdapter struct {
+	runTask RunTaskFunc
+}
+
+func NewNativeAdapter(runTask RunTaskFunc) *NativeAdapter {
+	return &NativeAdapter{runTask: runTask}
+}
+
+func (a *NativeAdapter) ID() string { return NativeAdapterID }
+
+func (a *NativeAdapter) RunTask(ctx context.Context, req TaskRequest) (TaskResult, error) {
+	if a == nil || a.runTask == nil {
+		return TaskResult{}, fmt.Errorf("native adapter is not configured")
+	}
+	result, err := a.runTask(ctx, req)
+	if err != nil {
+		return TaskResult{}, err
+	}
+	return NormalizeResult(result), nil
+}

--- a/pkg/harness/registry.go
+++ b/pkg/harness/registry.go
@@ -1,0 +1,76 @@
+package harness
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// Registry stores available harness adapters keyed by adapter ID.
+type Registry struct {
+	mu       sync.RWMutex
+	adapters map[string]Adapter
+}
+
+func NewRegistry(adapters ...Adapter) (*Registry, error) {
+	r := &Registry{adapters: map[string]Adapter{}}
+	for _, adapter := range adapters {
+		if err := r.Register(adapter); err != nil {
+			return nil, err
+		}
+	}
+	return r, nil
+}
+
+func (r *Registry) Register(adapter Adapter) error {
+	if r == nil {
+		return fmt.Errorf("harness registry is nil")
+	}
+	if adapter == nil {
+		return fmt.Errorf("adapter is nil")
+	}
+	id := normalizeAdapterID(adapter.ID())
+	if id == "" {
+		return fmt.Errorf("adapter id is required")
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, exists := r.adapters[id]; exists {
+		return fmt.Errorf("adapter %q already registered", id)
+	}
+	r.adapters[id] = adapter
+	return nil
+}
+
+func (r *Registry) Get(id string) (Adapter, bool) {
+	if r == nil {
+		return nil, false
+	}
+	id = normalizeAdapterID(id)
+	if id == "" {
+		return nil, false
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	adapter, ok := r.adapters[id]
+	return adapter, ok
+}
+
+func (r *Registry) IDs() []string {
+	if r == nil {
+		return nil
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]string, 0, len(r.adapters))
+	for id := range r.adapters {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func normalizeAdapterID(id string) string {
+	return strings.ToLower(strings.TrimSpace(id))
+}

--- a/pkg/harness/registry_test.go
+++ b/pkg/harness/registry_test.go
@@ -1,0 +1,42 @@
+package harness
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tinoosan/agen8/pkg/types"
+)
+
+type fakeAdapter struct{ id string }
+
+func (f fakeAdapter) ID() string { return f.id }
+func (f fakeAdapter) RunTask(context.Context, TaskRequest) (TaskResult, error) {
+	return TaskResult{Status: types.TaskStatusSucceeded}, nil
+}
+
+func TestRegistryRegisterLookupAndIDs(t *testing.T) {
+	r, err := NewRegistry(fakeAdapter{id: "one"})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	if err := r.Register(fakeAdapter{id: "Two"}); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if _, ok := r.Get("two"); !ok {
+		t.Fatalf("expected adapter 'two' to be registered")
+	}
+	ids := r.IDs()
+	if len(ids) != 2 || ids[0] != "one" || ids[1] != "two" {
+		t.Fatalf("IDs = %#v", ids)
+	}
+}
+
+func TestRegistryRejectsDuplicateIDs(t *testing.T) {
+	r, err := NewRegistry(fakeAdapter{id: "one"})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	if err := r.Register(fakeAdapter{id: "ONE"}); err == nil {
+		t.Fatalf("expected duplicate adapter registration to fail")
+	}
+}

--- a/pkg/harness/selector.go
+++ b/pkg/harness/selector.go
@@ -1,0 +1,51 @@
+package harness
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// HarnessIDFromMetadata returns task-level harness selection (if present).
+func HarnessIDFromMetadata(metadata map[string]any) string {
+	if len(metadata) == 0 {
+		return ""
+	}
+	raw, ok := metadata["harnessId"]
+	if !ok || raw == nil {
+		return ""
+	}
+	return normalizeAdapterID(fmt.Sprint(raw))
+}
+
+// SelectHarnessID resolves harness selection with this precedence:
+// task metadata -> run runtime -> env AGEN8_DEFAULT_HARNESS -> agen8-native.
+func SelectHarnessID(taskMetadata map[string]any, runHarnessID string, envLookup func(string) string) string {
+	if id := HarnessIDFromMetadata(taskMetadata); id != "" {
+		return id
+	}
+	if id := normalizeAdapterID(runHarnessID); id != "" {
+		return id
+	}
+	lookup := envLookup
+	if lookup == nil {
+		lookup = os.Getenv
+	}
+	if id := normalizeAdapterID(lookup(DefaultHarnessEnvVar)); id != "" {
+		return id
+	}
+	return NativeAdapterID
+}
+
+func SetHarnessIDMetadata(metadata map[string]any, harnessID string) map[string]any {
+	harnessID = normalizeAdapterID(harnessID)
+	if metadata == nil {
+		metadata = map[string]any{}
+	}
+	if harnessID == "" {
+		delete(metadata, "harnessId")
+		return metadata
+	}
+	metadata["harnessId"] = strings.TrimSpace(harnessID)
+	return metadata
+}

--- a/pkg/harness/selector_test.go
+++ b/pkg/harness/selector_test.go
@@ -1,0 +1,37 @@
+package harness
+
+import "testing"
+
+func TestSelectHarnessIDPrecedence(t *testing.T) {
+	meta := map[string]any{"harnessId": "custom-a"}
+	id := SelectHarnessID(meta, "run-a", func(string) string { return "env-a" })
+	if id != "custom-a" {
+		t.Fatalf("metadata precedence failed: got %q", id)
+	}
+
+	id = SelectHarnessID(nil, "run-a", func(string) string { return "env-a" })
+	if id != "run-a" {
+		t.Fatalf("run precedence failed: got %q", id)
+	}
+
+	id = SelectHarnessID(nil, "", func(string) string { return "env-a" })
+	if id != "env-a" {
+		t.Fatalf("env precedence failed: got %q", id)
+	}
+
+	id = SelectHarnessID(nil, "", func(string) string { return "" })
+	if id != NativeAdapterID {
+		t.Fatalf("fallback failed: got %q", id)
+	}
+}
+
+func TestSetHarnessIDMetadata(t *testing.T) {
+	meta := SetHarnessIDMetadata(nil, "Codex-CLI")
+	if got := HarnessIDFromMetadata(meta); got != "codex-cli" {
+		t.Fatalf("HarnessIDFromMetadata = %q", got)
+	}
+	meta = SetHarnessIDMetadata(meta, "")
+	if got := HarnessIDFromMetadata(meta); got != "" {
+		t.Fatalf("expected empty harness id, got %q", got)
+	}
+}

--- a/pkg/protocol/rpc_parity.go
+++ b/pkg/protocol/rpc_parity.go
@@ -460,6 +460,7 @@ type RuntimeRunState struct {
 	SessionID       string  `json:"sessionId"`
 	RunID           string  `json:"runId"`
 	Model           string  `json:"model,omitempty"`
+	HarnessID       string  `json:"harnessId,omitempty"`
 	RunTotalTokens  int     `json:"runTotalTokens,omitempty"`
 	RunTotalCostUSD float64 `json:"runTotalCostUSD,omitempty"`
 	PersistedStatus string  `json:"persistedStatus,omitempty"`

--- a/pkg/protocol/task.go
+++ b/pkg/protocol/task.go
@@ -10,6 +10,8 @@ type Task struct {
 	RunID            RunID     `json:"runId"`
 	TeamID           string    `json:"teamId,omitempty"`
 	TaskKind         string    `json:"taskKind,omitempty"`
+	HarnessID        string    `json:"harnessId,omitempty"`
+	HarnessRunRef    string    `json:"harnessRunRef,omitempty"`
 	AssignedToType   string    `json:"assignedToType,omitempty"`
 	AssignedTo       string    `json:"assignedTo,omitempty"`
 	AssignedRole     string    `json:"assignedRole,omitempty"`
@@ -30,7 +32,7 @@ type Task struct {
 
 type TaskListParams struct {
 	ThreadID ThreadID `json:"threadId"`
-	View     string   `json:"view,omitempty"` // inbox|outbox
+	View     string   `json:"view,omitempty"`  // inbox|outbox
 	Scope    string   `json:"scope,omitempty"` // team|run (default: auto)
 	TeamID   string   `json:"teamId,omitempty"`
 	RunID    string   `json:"runId,omitempty"`
@@ -50,6 +52,7 @@ type TaskCreateParams struct {
 	RunID          string   `json:"runId,omitempty"`
 	Goal           string   `json:"goal"`
 	TaskKind       string   `json:"taskKind,omitempty"`
+	HarnessID      string   `json:"harnessId,omitempty"`
 	AssignedToType string   `json:"assignedToType,omitempty"`
 	AssignedTo     string   `json:"assignedTo,omitempty"`
 	AssignedRole   string   `json:"assignedRole,omitempty"`

--- a/pkg/types/run.go
+++ b/pkg/types/run.go
@@ -72,6 +72,8 @@ type RunRuntimeConfig struct {
 
 	// Model is the configured LLM model identifier for this run.
 	Model string `json:"model,omitempty"`
+	// HarnessID is the configured harness adapter identifier for this run.
+	HarnessID string `json:"harnessId,omitempty"`
 
 	// TeamID is set when the run belongs to a team context.
 	TeamID string `json:"teamId,omitempty"`


### PR DESCRIPTION
## Summary
- add a new harness contract layer (`pkg/harness`) with adapter registry + selection precedence
- route task execution through harness selection in session runtime while preserving native behavior
- add Codex CLI adapter (`codex-cli`) and runtime wiring for adapter registration
- extend protocol/runtime/task surfaces with optional `harnessId` and `harnessRunRef`
- emit harness lifecycle events (`harness.selected`, `harness.run.start`, `harness.run.complete`, `harness.run.error`, `harness.usage.reported`)
- enhance observability commands and add aliases: `status`, `feed`, `trace`, `costs`
- update AGENT.md pivot guardrails and README identity/command references

## Key Details
- harness selection precedence: task metadata -> run runtime -> `AGEN8_DEFAULT_HARNESS` -> `agen8-native`
- no DB schema migration; harness metadata stored in `metadata_json`
- existing command surfaces remain compatible

## Testing
- `go test ./...`
- added targeted tests for harness registry/selector, session external harness routing, rpc harness mapping, and alias command registration
