### PR TITLE
Enforce project ownership at shared service boundary

### DIFF
--- a/internal/daemon/http_upload.go
+++ b/internal/daemon/http_upload.go
@@ -71,7 +71,7 @@ func (d *Daemon) handleFileUpload(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "attachment upload file is too large", http.StatusRequestEntityTooLarge)
 			return
 		}
-		http.Error(w, "upload file: "+err.Error(), http.StatusBadRequest)
+		http.Error(w, "attachment upload failed", http.StatusBadRequest)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/daemon/http_upload_test.go
+++ b/internal/daemon/http_upload_test.go
@@ -90,6 +90,31 @@ func TestHandleFileUploadRejectsOverCeilingCleanly(t *testing.T) {
 	}
 }
 
+func TestHandleFileUploadRedactsServiceErrors(t *testing.T) {
+	projectRoot := t.TempDir()
+	handler := newUploadTestHandler(t)
+	sessionToken := setupSessionForEventsTest(t, handler)
+	projectID := createProjectForLinkTokenTest(t, handler, sessionToken, projectRoot)
+
+	body, contentType := multipartUploadBody(t, map[string]string{
+		"projectId": projectID,
+		"path":      "/outside/secret.txt",
+	}, []byte("secret"), "secret.txt")
+	req := httptest.NewRequest(http.MethodPost, "/uploads/files", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+sessionToken)
+	req.Header.Set("Content-Type", contentType)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status=%d want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+	if strings.TrimSpace(rec.Body.String()) != "attachment upload failed" {
+		t.Fatalf("upload error disclosed backend detail: %q", rec.Body.String())
+	}
+}
+
 func newUploadTestHandler(t *testing.T) http.Handler {
 	t.Helper()
 	d, err := New(Config{

--- a/internal/rpc/project.go
+++ b/internal/rpc/project.go
@@ -62,7 +62,7 @@ func RegisterProject(reg *Registry, projectSvc *projectapp.Service, postCreate P
 	handler := projectrpc.NewHandler(projectSvc, rootValidators...)
 	return RegisterHandlers(
 		func() error {
-			return AddBoundHandler(reg, MethodProjectGet, false, handler.ProjectGet)
+			return AddBoundHandler(reg, MethodProjectGet, false, withProjectCaller(handler.ProjectGet))
 		},
 		func() error {
 			return AddBoundHandler(reg, MethodProjectCreate, false, withProjectCaller(func(ctx context.Context, p projectrpc.ProjectCreateParams) (projectrpc.ProjectCreateResult, error) {
@@ -110,13 +110,13 @@ func RegisterProject(reg *Registry, projectSvc *projectapp.Service, postCreate P
 			return AddBoundHandler(reg, MethodProjectRelocate, false, withProjectCaller(handler.ProjectRelocate))
 		},
 		func() error {
-			return AddBoundHandler(reg, MethodProjectArchive, false, handler.ProjectArchive)
+			return AddBoundHandler(reg, MethodProjectArchive, false, withProjectCaller(handler.ProjectArchive))
 		},
 		func() error {
-			return AddBoundHandler(reg, MethodProjectDelete, false, handler.ProjectDelete)
+			return AddBoundHandler(reg, MethodProjectDelete, false, withProjectCaller(handler.ProjectDelete))
 		},
 		func() error {
-			return AddBoundHandler(reg, MethodProjectList, true, handler.ProjectList)
+			return AddBoundHandler(reg, MethodProjectList, true, withProjectCaller(handler.ProjectList))
 		},
 		func() error {
 			return AddBoundHandler(reg, MethodProjectLinkTokenCreate, false, withProjectCaller(handler.LinkTokenCreate))

--- a/internal/services/project/app/mcp_context.go
+++ b/internal/services/project/app/mcp_context.go
@@ -100,7 +100,7 @@ func (s *Service) RegisterMCPContext(ctx context.Context, input RegisterMCPConte
 	}
 	userID := userIDForMCPToken(token, input.UserID)
 	ctx = caller.ContextWithCaller(ctx, caller.Caller{UserID: userID})
-	loadedProject, err := s.GetProject(ctx, projectID)
+	loadedProject, err := s.loadProject(ctx, projectID)
 	if err != nil {
 		if !errors.Is(err, project.ErrNotFound) {
 			return RegisterMCPContextResult{}, fmt.Errorf("load project: %w", err)

--- a/internal/services/project/app/service.go
+++ b/internal/services/project/app/service.go
@@ -253,6 +253,23 @@ func (s *Service) GetProject(ctx context.Context, projectID types.ProjectID) (pr
 	if projectID == "" {
 		return project.Project{}, fmt.Errorf("project id is required")
 	}
+	c, err := s.resolveCaller(ctx)
+	if err != nil {
+		return project.Project{}, err
+	}
+	loaded, err := s.loadProject(ctx, projectID)
+	if err != nil {
+		return project.Project{}, err
+	}
+	if err := s.requireProjectVisibility(ctx, c, loaded); err != nil {
+		return project.Project{}, err
+	}
+	return loaded, nil
+}
+
+// loadProject bypasses caller visibility for service-internal migration paths.
+// User-facing operations must call GetProject so authorization cannot be skipped.
+func (s *Service) loadProject(ctx context.Context, projectID types.ProjectID) (project.Project, error) {
 	record, err := s.projects.Get(ctx, projectID)
 	if err != nil {
 		return project.Project{}, err
@@ -266,6 +283,25 @@ func (s *Service) ListProjects(ctx context.Context, filter project.Filter) ([]pr
 	}
 	if filter.Limit < 0 || filter.Offset < 0 {
 		return nil, fmt.Errorf("project limit and offset must be non-negative")
+	}
+	c, err := s.resolveCaller(ctx)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case c.UserID != "":
+		filter.UserID = c.UserID
+		filter.ID = ""
+	case c.ProjectID != "":
+		filter.ID = c.ProjectID
+		filter.UserID = ""
+	case c.MemberID != "":
+		rosterMember, err := s.members.Get(ctx, string(c.MemberID))
+		if err != nil {
+			return nil, fmt.Errorf("load project caller member: %w", err)
+		}
+		filter.ID = types.ProjectID(strings.TrimSpace(rosterMember.ProjectID))
+		filter.UserID = ""
 	}
 	records, err := s.projects.List(ctx, filter)
 	if err != nil {
@@ -353,6 +389,13 @@ func (s *Service) ArchiveProject(ctx context.Context, projectID types.ProjectID)
 	if err != nil {
 		return project.Project{}, err
 	}
+	c, err := s.resolveCaller(ctx)
+	if err != nil {
+		return project.Project{}, err
+	}
+	if err := requireOwnedProject(c, current); err != nil {
+		return project.Project{}, err
+	}
 	record := current.Record()
 	record.Status = project.StatusArchived
 	record.UpdatedAt = s.now()
@@ -369,6 +412,13 @@ func (s *Service) DeleteProject(ctx context.Context, projectID types.ProjectID) 
 	}
 	current, err := s.GetProject(ctx, projectID)
 	if err != nil {
+		return err
+	}
+	c, err := s.resolveCaller(ctx)
+	if err != nil {
+		return err
+	}
+	if err := requireOwnedProject(c, current); err != nil {
 		return err
 	}
 	if current.Status() != project.StatusArchived {
@@ -396,6 +446,23 @@ func requireVisibleProject(c Caller, p project.Project) error {
 		return nil
 	}
 	if c.ProjectID != "" && p.ID() == c.ProjectID {
+		return nil
+	}
+	return fmt.Errorf("project %s is not visible to caller", p.ID())
+}
+
+func (s *Service) requireProjectVisibility(ctx context.Context, c Caller, p project.Project) error {
+	if err := requireVisibleProject(c, p); err == nil {
+		return nil
+	}
+	if c.MemberID == "" {
+		return fmt.Errorf("project %s is not visible to caller", p.ID())
+	}
+	rosterMember, err := s.members.Get(ctx, string(c.MemberID))
+	if err != nil {
+		return fmt.Errorf("load project caller member: %w", err)
+	}
+	if types.ProjectID(strings.TrimSpace(rosterMember.ProjectID)) == p.ID() {
 		return nil
 	}
 	return fmt.Errorf("project %s is not visible to caller", p.ID())

--- a/internal/services/project/app/service_test.go
+++ b/internal/services/project/app/service_test.go
@@ -60,6 +60,36 @@ func TestSaveProjectStampsOwningUser(t *testing.T) {
 	}
 }
 
+func TestProjectReadsAreScopedToCaller(t *testing.T) {
+	t.Parallel()
+	svc := newProjectServiceWithIssuer(t, &fakeLinkTokenIssuer{})
+	ownerA := caller.ContextWithCaller(context.Background(), caller.Caller{UserID: "user-a"})
+	ownerB := caller.ContextWithCaller(context.Background(), caller.Caller{UserID: "user-b"})
+
+	projectA, err := svc.CreateProject(ownerA, CreateProjectInput{Root: "/work/a", Title: "A"})
+	if err != nil {
+		t.Fatalf("create project A: %v", err)
+	}
+	projectB, err := svc.CreateProject(ownerB, CreateProjectInput{Root: "/work/b", Title: "B"})
+	if err != nil {
+		t.Fatalf("create project B: %v", err)
+	}
+
+	if _, err := svc.GetProject(ownerA, projectB.ID()); err == nil {
+		t.Fatal("owner A read owner B's project")
+	}
+	listed, err := svc.ListProjects(ownerA, project.Filter{})
+	if err != nil {
+		t.Fatalf("list owner A projects: %v", err)
+	}
+	if len(listed) != 1 || listed[0].ID() != projectA.ID() {
+		t.Fatalf("owner A projects=%v want only %s", listed, projectA.ID())
+	}
+	if _, err := svc.ArchiveProject(ownerA, projectB.ID()); err == nil {
+		t.Fatal("owner A archived owner B's project")
+	}
+}
+
 // Deletion is a deliberate two-step: a project must be archived before it can be
 // permanently removed. Deleting an open project must return ErrNotArchived (a
 // client precondition the RPC layer surfaces as invalid-params), NOT a generic

--- a/internal/services/project/domain/project/repository.go
+++ b/internal/services/project/domain/project/repository.go
@@ -23,6 +23,8 @@ type Record struct {
 }
 
 type Filter struct {
+	ID     types.ProjectID
+	UserID string
 	Status Status
 	Limit  int
 	Offset int

--- a/internal/services/project/infra/helpers.go
+++ b/internal/services/project/infra/helpers.go
@@ -96,29 +96,6 @@ func parseTime(value string) time.Time {
 	return t.UTC()
 }
 
-func projectWhere(filter project.Filter) (string, []any, error) {
-	if filter.Limit < 0 || filter.Offset < 0 {
-		return "", nil, fmt.Errorf("project limit and offset must be non-negative")
-	}
-	var clauses []string
-	var args []any
-	if filter.Status != "" {
-		clauses = append(clauses, "status = ?")
-		args = append(args, strings.TrimSpace(string(filter.Status)))
-	}
-	if len(clauses) == 0 {
-		return "", args, nil
-	}
-	return " WHERE " + strings.Join(clauses, " AND "), args, nil
-}
-
-func projectMatchesFilter(record project.Record, filter project.Filter) bool {
-	if filter.Status != "" && record.Status != project.Status(strings.TrimSpace(string(filter.Status))) {
-		return false
-	}
-	return true
-}
-
 func scanProject(scanner interface{ Scan(dest ...any) error }) (project.Record, error) {
 	var record project.Record
 	var createdAt, updatedAt, customization string

--- a/internal/services/project/infra/sqlite_repository.go
+++ b/internal/services/project/infra/sqlite_repository.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/tinoosan/agen8/internal/core/types"
@@ -48,53 +47,30 @@ func (r *SQLiteRepository) Get(ctx context.Context, id types.ProjectID) (project
 }
 
 func (r *SQLiteRepository) List(ctx context.Context, filter project.Filter) ([]project.Record, error) {
-	_, _, err := projectWhere(filter)
-	if err != nil {
-		return nil, err
+	if filter.Limit < 0 || filter.Offset < 0 {
+		return nil, fmt.Errorf("project limit and offset must be non-negative")
+	}
+	projectID := strings.TrimSpace(string(filter.ID))
+	userID := strings.TrimSpace(filter.UserID)
+	status := strings.TrimSpace(string(filter.Status))
+	limit := filter.Limit
+	if limit == 0 {
+		limit = -1
 	}
 	rows, err := r.db.QueryContext(ctx, `
 		SELECT project_id, location_id, root, title, status, created_at, updated_at, user_id, customization
 		FROM projects
-	`)
+		WHERE (? = '' OR project_id = ?)
+			AND (? = '' OR user_id = ?)
+			AND (? = '' OR status = ?)
+		ORDER BY updated_at DESC, project_id ASC
+		LIMIT ? OFFSET ?
+	`, projectID, projectID, userID, userID, status, status, limit, filter.Offset)
 	if err != nil {
 		return nil, fmt.Errorf("list projects: %w", err)
 	}
 	defer rows.Close()
-	all, err := scanProjects(rows)
-	if err != nil {
-		return nil, err
-	}
-	filtered := make([]project.Record, 0, len(all))
-	for _, record := range all {
-		if projectMatchesFilter(record, filter) {
-			filtered = append(filtered, record)
-		}
-	}
-	sort.SliceStable(filtered, func(i, j int) bool {
-		left := filtered[i]
-		right := filtered[j]
-		leftUpdated := left.UpdatedAt.UTC()
-		rightUpdated := right.UpdatedAt.UTC()
-		if !leftUpdated.Equal(rightUpdated) {
-			return leftUpdated.After(rightUpdated)
-		}
-		return string(left.ID) < string(right.ID)
-	})
-	start := 0
-	if filter.Offset > 0 {
-		start = filter.Offset
-	}
-	if start >= len(filtered) {
-		return []project.Record{}, nil
-	}
-	end := len(filtered)
-	if filter.Limit > 0 {
-		end = start + filter.Limit
-	}
-	if end > len(filtered) {
-		end = len(filtered)
-	}
-	return filtered[start:end], nil
+	return scanProjects(rows)
 }
 
 func (r *SQLiteRepository) Save(ctx context.Context, record project.Record) (project.Record, error) {


### PR DESCRIPTION
## Summary
- scope project reads and lists to the authenticated caller
- require project ownership for archive and delete
- protect file uploads through the shared project loader and redact backend errors
- execute scoped project filtering and pagination in SQLite

## Verification
- go test ./...
- go vet ./...
- staticcheck ./...
- gosec -quiet -exclude-generated ./...