### PR TITLE
Reject ambiguous multipart uploads

### DIFF
--- a/internal/daemon/http_upload.go
+++ b/internal/daemon/http_upload.go
@@ -21,7 +21,10 @@ const (
 	maxAttachmentUploadFieldBytes   int64 = 64 << 10
 )
 
-var errAttachmentUploadFileTooLarge = errors.New("attachment upload file is too large")
+var (
+	errAttachmentUploadFileTooLarge = errors.New("attachment upload file is too large")
+	errAttachmentUploadTrailingPart = errors.New("file must be the final multipart field")
+)
 
 func (d *Daemon) handleFileUpload(w http.ResponseWriter, r *http.Request) {
 	usesSessionCookie := strings.TrimSpace(r.Header.Get("Authorization")) == "" && requestHasSessionCookie(r)
@@ -80,7 +83,7 @@ func (d *Daemon) handleFileUpload(w http.ResponseWriter, r *http.Request) {
 
 func decodeFileUploadMultipart(reader *multipart.Reader) (fileapp.UploadReaderInput, error) {
 	var input fileapp.UploadReaderInput
-	var fileSeen bool
+	seen := make(map[string]struct{}, 4)
 	for {
 		part, err := reader.NextPart()
 		if errors.Is(err, io.EOF) {
@@ -89,7 +92,12 @@ func decodeFileUploadMultipart(reader *multipart.Reader) (fileapp.UploadReaderIn
 		if err != nil {
 			return fileapp.UploadReaderInput{}, err
 		}
-		switch part.FormName() {
+		field := strings.TrimSpace(part.FormName())
+		if _, duplicate := seen[field]; duplicate {
+			return fileapp.UploadReaderInput{}, fmt.Errorf("%s field must be provided once", field)
+		}
+		seen[field] = struct{}{}
+		switch field {
 		case "projectId":
 			value, err := readUploadField(part)
 			if err != nil {
@@ -109,15 +117,19 @@ func decodeFileUploadMultipart(reader *multipart.Reader) (fileapp.UploadReaderIn
 			}
 			input.Path = value
 		case "file":
-			if fileSeen {
-				return fileapp.UploadReaderInput{}, fmt.Errorf("file field must be provided once")
+			if err := validateFileUploadInput(input, true); err != nil {
+				return fileapp.UploadReaderInput{}, err
 			}
-			input.Reader = &attachmentUploadLimitReader{r: part, remaining: maxAttachmentUploadFileBytes}
-			fileSeen = true
-			return input, validateFileUploadInput(input, fileSeen)
+			input.Reader = &finalMultipartFileReader{
+				file:      &attachmentUploadLimitReader{r: part, remaining: maxAttachmentUploadFileBytes},
+				multipart: reader,
+			}
+			return input, nil
+		default:
+			return fileapp.UploadReaderInput{}, fmt.Errorf("unsupported multipart field %q", field)
 		}
 	}
-	return input, validateFileUploadInput(input, fileSeen)
+	return input, validateFileUploadInput(input, false)
 }
 
 func validateFileUploadInput(input fileapp.UploadReaderInput, fileSeen bool) error {
@@ -147,6 +159,32 @@ func readUploadField(part *multipart.Part) (string, error) {
 type attachmentUploadLimitReader struct {
 	r         io.Reader
 	remaining int64
+}
+
+// finalMultipartFileReader preserves streaming while proving that the file is
+// the final part. A trailing field becomes a read error, so the file service's
+// atomic writer cannot commit an upload whose metadata was silently ignored.
+type finalMultipartFileReader struct {
+	file      io.Reader
+	multipart *multipart.Reader
+	validated bool
+}
+
+func (r *finalMultipartFileReader) Read(p []byte) (int, error) {
+	n, err := r.file.Read(p)
+	if !errors.Is(err, io.EOF) || r.validated {
+		return n, err
+	}
+	r.validated = true
+	part, nextErr := r.multipart.NextPart()
+	if errors.Is(nextErr, io.EOF) {
+		return n, io.EOF
+	}
+	if nextErr != nil {
+		return n, fmt.Errorf("validate multipart trailer: %w", nextErr)
+	}
+	_ = part.Close()
+	return n, errAttachmentUploadTrailingPart
 }
 
 func (r *attachmentUploadLimitReader) Read(p []byte) (int, error) {

--- a/internal/daemon/http_upload_test.go
+++ b/internal/daemon/http_upload_test.go
@@ -115,6 +115,77 @@ func TestHandleFileUploadRedactsServiceErrors(t *testing.T) {
 	}
 }
 
+func TestHandleFileUploadRejectsTrailingMultipartFieldsWithoutWriting(t *testing.T) {
+	projectRoot := t.TempDir()
+	handler := newUploadTestHandler(t)
+	sessionToken := setupSessionForEventsTest(t, handler)
+	projectID := createProjectForLinkTokenTest(t, handler, sessionToken, projectRoot)
+	path := "/project/.agen8/attachments/task-1/trailing.txt"
+
+	body, contentType := orderedMultipartUploadBody(t, []multipartUploadPart{
+		{field: "projectId", value: projectID},
+		{field: "path", value: path},
+		{field: "file", value: "content", fileName: "trailing.txt"},
+		{field: "path", value: "/project/ignored.txt"},
+	})
+	rec := performUploadRequest(handler, sessionToken, body, contentType)
+
+	if rec.Code != http.StatusBadRequest || strings.TrimSpace(rec.Body.String()) != "attachment upload failed" {
+		t.Fatalf("status=%d body=%q want redacted rejection", rec.Code, rec.Body.String())
+	}
+	if _, err := os.Stat(filepath.Join(projectRoot, ".agen8", "attachments", "task-1", "trailing.txt")); !os.IsNotExist(err) {
+		t.Fatalf("trailing multipart upload wrote a file, stat err=%v", err)
+	}
+}
+
+func TestHandleFileUploadRejectsAmbiguousMetadata(t *testing.T) {
+	projectRoot := t.TempDir()
+	handler := newUploadTestHandler(t)
+	sessionToken := setupSessionForEventsTest(t, handler)
+	projectID := createProjectForLinkTokenTest(t, handler, sessionToken, projectRoot)
+
+	tests := []struct {
+		name  string
+		parts []multipartUploadPart
+	}{
+		{
+			name: "duplicate path",
+			parts: []multipartUploadPart{
+				{field: "projectId", value: projectID},
+				{field: "path", value: "/project/first.txt"},
+				{field: "path", value: "/project/second.txt"},
+				{field: "file", value: "content", fileName: "file.txt"},
+			},
+		},
+		{
+			name: "unknown field",
+			parts: []multipartUploadPart{
+				{field: "projectId", value: projectID},
+				{field: "path", value: "/project/file.txt"},
+				{field: "destination", value: "/project/other.txt"},
+				{field: "file", value: "content", fileName: "file.txt"},
+			},
+		},
+		{
+			name: "file before metadata",
+			parts: []multipartUploadPart{
+				{field: "file", value: "content", fileName: "file.txt"},
+				{field: "projectId", value: projectID},
+				{field: "path", value: "/project/file.txt"},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			body, contentType := orderedMultipartUploadBody(t, test.parts)
+			rec := performUploadRequest(handler, sessionToken, body, contentType)
+			if rec.Code != http.StatusBadRequest {
+				t.Fatalf("status=%d want %d body=%s", rec.Code, http.StatusBadRequest, rec.Body.String())
+			}
+		})
+	}
+}
+
 func newUploadTestHandler(t *testing.T) http.Handler {
 	t.Helper()
 	d, err := New(Config{
@@ -151,4 +222,44 @@ func multipartUploadBody(t *testing.T, fields map[string]string, data []byte, fi
 		t.Fatalf("close multipart writer: %v", err)
 	}
 	return body.Bytes(), writer.FormDataContentType()
+}
+
+type multipartUploadPart struct {
+	field    string
+	value    string
+	fileName string
+}
+
+func orderedMultipartUploadBody(t *testing.T, parts []multipartUploadPart) ([]byte, string) {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	for _, part := range parts {
+		if part.fileName == "" {
+			if err := writer.WriteField(part.field, part.value); err != nil {
+				t.Fatalf("write field %s: %v", part.field, err)
+			}
+			continue
+		}
+		file, err := writer.CreateFormFile(part.field, part.fileName)
+		if err != nil {
+			t.Fatalf("create file part: %v", err)
+		}
+		if _, err := file.Write([]byte(part.value)); err != nil {
+			t.Fatalf("write file part: %v", err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+	return body.Bytes(), writer.FormDataContentType()
+}
+
+func performUploadRequest(handler http.Handler, sessionToken string, body []byte, contentType string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/uploads/files", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+sessionToken)
+	req.Header.Set("Content-Type", contentType)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
 }


### PR DESCRIPTION
## Summary
- reject duplicate and unsupported multipart metadata
- require metadata before the streaming file part
- verify the file is the final multipart part before atomically committing it
- cover duplicate, unknown, misordered, and trailing-part failures

## Verification
- go test ./...
- go vet ./...
- staticcheck ./...
- gosec -quiet -exclude-generated ./...