### PR TITLE
Shrink and continuously scan the release container

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Run security checks
         run: |
           govulncheck ./...
-          gosec -quiet ./internal/daemon/... ./internal/hookinstaller/...
+          gosec -quiet -exclude-generated ./...
 
       - name: Validate Kubernetes manifest
         run: |
@@ -107,3 +107,60 @@ jobs:
 
       - name: Reject production source maps
         run: test -z "$(find ../internal/web/dist -type f -name '*.map' -print -quit)"
+
+  container:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build release container
+        run: |
+          docker build \
+            --build-arg VERSION=ci \
+            --build-arg COMMIT="$GITHUB_SHA" \
+            --build-arg BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --tag agen8:ci \
+            .
+
+      - name: Verify runtime contract
+        run: |
+          test "$(docker image inspect agen8:ci --format '{{.Config.User}}')" = "agen8"
+          size="$(docker image inspect agen8:ci --format '{{.Size}}')"
+          echo "Uncompressed image size: ${size} bytes"
+          test "$size" -lt 170000000
+          docker run --rm --entrypoint git agen8:ci --version
+
+          container_id="$(docker run --detach \
+            --read-only \
+            --tmpfs /data:uid=10001,gid=10001,mode=0700 \
+            --tmpfs /tmp:uid=10001,gid=10001,mode=0700 \
+            agen8:ci)"
+          trap 'docker rm --force "$container_id" >/dev/null 2>&1 || true' EXIT
+          for _ in $(seq 1 30); do
+            health="$(docker inspect --format '{{.State.Health.Status}}' "$container_id")"
+            if [ "$health" = "healthy" ]; then
+              exit 0
+            fi
+            if [ "$health" = "unhealthy" ]; then
+              docker logs "$container_id"
+              exit 1
+            fi
+            sleep 2
+          done
+          docker logs "$container_id"
+          exit 1
+
+      - name: Scan release container
+        run: |
+          mkdir -p "$RUNNER_TEMP/trivy-cache"
+          docker run --rm \
+            --volume /var/run/docker.sock:/var/run/docker.sock \
+            --volume "$RUNNER_TEMP/trivy-cache:/root/.cache/trivy" \
+            aquasec/trivy@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f \
+            image \
+            --scanners vuln \
+            --severity HIGH,CRITICAL \
+            --ignore-unfixed \
+            --exit-code 1 \
+            agen8:ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,12 +26,13 @@ RUN CGO_ENABLED=0 GOOS=linux go build -trimpath \
 	-ldflags="-s -w -X github.com/tinoosan/agen8/pkg/buildinfo.Version=${VERSION} -X github.com/tinoosan/agen8/pkg/buildinfo.Commit=${COMMIT} -X github.com/tinoosan/agen8/pkg/buildinfo.BuildDate=${BUILD_DATE}" \
 	-o /out/agen8 ./cmd/agen8
 
-FROM debian:bookworm-slim AS runtime
+FROM alpine:3.22.5 AS runtime
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends ca-certificates git \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& useradd --system --uid 10001 --home-dir /data --create-home --shell /usr/sbin/nologin agen8
+RUN apk add --no-cache ca-certificates git \
+	&& addgroup -S -g 10001 agen8 \
+	&& adduser -S -D -H -u 10001 -G agen8 -s /sbin/nologin agen8 \
+	&& mkdir -p /data \
+	&& chown agen8:agen8 /data
 
 COPY --from=go-builder /out/agen8 /usr/local/bin/agen8
 


### PR DESCRIPTION
## Summary
- replace the 216 MB Debian runtime with patched Alpine 3.22.5
- retain Git, CA roots, UID 10001, health checks, and read-only-root compatibility
- add a CI container build, runtime smoke test, size regression gate, and digest-pinned Trivy scan
- make CI run gosec across every Go package

## Baseline
- previous uncompressed image: 216,370,162 bytes
- previous candidate passed non-root/read-only health smoke testing
- CI reports the optimized image size and blocks regressions above 170 MB