### PR TITLE
Connect Claude once per Agen8 account

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,25 +159,28 @@ harness will use to talk to Agen8. Copy it somewhere safe.
 
 ### 5. Connect a harness
 
-For Claude Code, run one command from the local project directory. It installs
-the Agen8 skills, project attention hooks, and a local-scope MCP connection:
+For Claude Code, run one account-level command. It installs the Agen8 skills,
+attention hooks, and a user-scope MCP connection used in every project:
 
 ```sh
 agen8 client setup --harness claude \
+  --scope user \
   --url http://127.0.0.1:7777 \
   --token ak_...
 ```
 
-The Projects page generates this command automatically for both new and
-existing projects. Re-running it repairs or refreshes the client setup. Project
-display-name changes do not require reconnecting Claude. Run it from the local
-project directory or pass `--project-dir /path/to/local/project`.
+The dashboard and Account page generate this command. Run it once; new and
+existing folders register themselves when Claude starts there. Re-running it
+rotates the credential and repairs user-level setup. The current directory is
+used only to remove a stale project-local Agen8 override, or can be supplied
+with `--project-dir`.
 
 If a project folder itself moves or is renamed, use **Project actions > Change
 project folder**. Agen8 validates the replacement directory and keeps the same
 project ID, history, members, missions, and tasks. It never moves files on disk.
-Afterward, run **Configure Claude MCP** for that project to generate a fresh
-project-bound client command when using a hosted daemon.
+Legacy project-bound connections can still be repaired with **Configure Claude
+MCP**, but account-level setup does not need reconnecting after a display-name
+change.
 
 For Codex or another MCP client, add a server entry pointing at the daemon and
 use the API key as a bearer token. `.mcp.example.json` at the repo root is a

--- a/cmd/agen8/client.go
+++ b/cmd/agen8/client.go
@@ -29,14 +29,15 @@ func newClientSetupCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(cmd.OutOrStdout(), "configured agen8 for %s\nproject: %s\nskills: %s\nhooks: %s\nmcp: %s\nserver: %s\n",
-				result.Harness, result.ProjectDir, result.SkillRoot, result.HooksPath, result.MCPPath, result.MCPURL)
+			fmt.Fprintf(cmd.OutOrStdout(), "configured agen8 for %s\nscope: %s\nproject: %s\nskills: %s\nhooks: %s\nmcp: %s\nserver: %s\n",
+				result.Harness, result.Scope, result.ProjectDir, result.SkillRoot, result.HooksPath, result.MCPPath, result.MCPURL)
 			return nil
 		},
 	}
 	cmd.Flags().StringVar(&opts.Harness, "harness", "claude", "target harness: claude")
 	cmd.Flags().StringVar(&opts.BaseURL, "url", "http://127.0.0.1:7777", "Agen8 daemon base URL")
 	cmd.Flags().StringVar(&opts.Token, "token", "", "Agen8 API key (ak_...)")
+	cmd.Flags().StringVar(&opts.Scope, "scope", "auto", "Claude configuration scope: auto, user, or local")
 	cmd.Flags().StringVar(&opts.ProjectDir, "project-dir", "", "local project directory (default: cwd)")
 	cmd.Flags().StringVar(&opts.HomeDir, "home", "", "home directory override")
 	return cmd

--- a/cmd/agen8/main_test.go
+++ b/cmd/agen8/main_test.go
@@ -92,7 +92,7 @@ func TestClientSetupInstallsClaudeIntegrations(t *testing.T) {
 	}
 	for _, path := range []string{
 		filepath.Join(home, ".claude", "skills", "agen8", "SKILL.md"),
-		filepath.Join(projectDir, ".claude", "settings.local.json"),
+		filepath.Join(home, ".claude", "settings.json"),
 	} {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("expected client artifact %s: %v", path, err)
@@ -104,14 +104,15 @@ func TestClientSetupInstallsClaudeIntegrations(t *testing.T) {
 	}
 	for _, want := range []string{
 		"configured agen8 for claude",
+		"scope: user",
 		"server: https://agen8.example.com/mcp",
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("output %q missing %q", output, want)
 		}
 	}
-	if !strings.Contains(string(calls), "mcp add-json --scope local agen8") {
-		t.Fatalf("claude calls missing local MCP install: %s", calls)
+	if !strings.Contains(string(calls), "mcp add-json --scope user agen8") {
+		t.Fatalf("claude calls missing user MCP install: %s", calls)
 	}
 }
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -171,23 +171,23 @@ export AGEN8_MCP_TOKEN='ak_...'
 Claude Code one-command setup:
 
 ```sh
-cd /path/to/local/project
 agen8 client setup --harness claude \
+  --scope user \
   --url https://agen8.example.com \
   --token ak_...
 ```
 
-This installs the Claude workflow skills, project attention hooks, and a
-local-scope MCP connection together. The Projects page generates the command
-for new and existing projects. Display-name changes do not require reconnecting
-Claude. Re-run the setup command from the local project directory to repair the
-client integration, or pass `--project-dir` explicitly.
+This installs the Claude workflow skills, account-level attention hooks, and a
+user-scope MCP connection together. Run it once for the developer account; new
+and existing project folders register when Claude starts there. Re-run it to
+rotate the credential or repair configuration. `--project-dir` identifies a
+current folder whose stale local Agen8 override should be removed.
 
 When a project folder moves or is renamed, use **Project actions > Change
 project folder**. The operation keeps the existing project ID and validates the
-new directory on the project's configured location. Hosted setup commands use
-project-bound `wlt_` credentials, so generate a fresh command with **Configure
-Claude MCP** after relocating the project.
+new directory on the project's configured location. Legacy hosted project
+commands may use project-bound `wlt_` credentials and remain local-scope.
+Account-level `ak_` setup does not need reinstalling after relocation.
 
 Install the Agen8 workflow skill for Codex locally:
 

--- a/internal/clientsetup/setup.go
+++ b/internal/clientsetup/setup.go
@@ -16,10 +16,17 @@ import (
 
 const HarnessClaude = "claude"
 
+const (
+	ScopeAuto  = "auto"
+	ScopeLocal = "local"
+	ScopeUser  = "user"
+)
+
 type Options struct {
 	Harness    string
 	BaseURL    string
 	Token      string
+	Scope      string
 	ProjectDir string
 	HomeDir    string
 	Context    context.Context
@@ -32,6 +39,7 @@ type Result struct {
 	HooksPath  string
 	MCPPath    string
 	MCPURL     string
+	Scope      string
 }
 
 // Install validates the complete request before writing, then performs the
@@ -48,6 +56,10 @@ func Install(opts Options) (Result, error) {
 	}
 	if strings.TrimSpace(opts.Token) == "" {
 		return Result{}, fmt.Errorf("client setup: --token is required")
+	}
+	scope, err := setupScope(opts.Scope, opts.Token)
+	if err != nil {
+		return Result{}, err
 	}
 	projectDir := strings.TrimSpace(opts.ProjectDir)
 	if projectDir == "" {
@@ -77,9 +89,11 @@ func Install(opts Options) (Result, error) {
 	}
 	hooks, err := hookinstaller.Install(hookinstaller.Options{
 		Harness:    hookinstaller.HarnessClaude,
+		Scope:      hookinstaller.Scope(scope),
 		BaseURL:    baseURL,
 		Token:      opts.Token,
 		ProjectDir: projectDir,
+		HomeDir:    strings.TrimSpace(opts.HomeDir),
 	})
 	if err != nil {
 		return Result{}, fmt.Errorf("client setup: install hooks: %w", err)
@@ -87,6 +101,7 @@ func Install(opts Options) (Result, error) {
 	mcpResult, err := hookinstaller.InstallClaudeMCP(hookinstaller.MCPOptions{
 		BaseURL:    baseURL,
 		Token:      opts.Token,
+		Scope:      hookinstaller.Scope(scope),
 		ProjectDir: projectDir,
 		Context:    opts.Context,
 	})
@@ -100,5 +115,23 @@ func Install(opts Options) (Result, error) {
 		HooksPath:  hooks.Path,
 		MCPPath:    mcpResult.Path,
 		MCPURL:     mcpResult.URL,
+		Scope:      scope,
 	}, nil
+}
+
+func setupScope(requested string, token string) (string, error) {
+	requested = strings.ToLower(strings.TrimSpace(requested))
+	if requested == "" || requested == ScopeAuto {
+		if strings.HasPrefix(strings.TrimSpace(token), "wlt_") {
+			return ScopeLocal, nil
+		}
+		return ScopeUser, nil
+	}
+	if requested != ScopeLocal && requested != ScopeUser {
+		return "", fmt.Errorf("client setup: --scope must be auto, local, or user")
+	}
+	if requested == ScopeUser && strings.HasPrefix(strings.TrimSpace(token), "wlt_") {
+		return "", fmt.Errorf("client setup: project-bound wlt_ tokens cannot be installed at user scope")
+	}
+	return requested, nil
 }

--- a/internal/clientsetup/setup_test.go
+++ b/internal/clientsetup/setup_test.go
@@ -1,0 +1,33 @@
+package clientsetup
+
+import "testing"
+
+func TestSetupScopeSelectsCredentialBoundary(t *testing.T) {
+	tests := []struct {
+		name      string
+		requested string
+		token     string
+		want      string
+		wantError bool
+	}{
+		{name: "account key defaults user", token: "ak_account", want: ScopeUser},
+		{name: "project token defaults local", token: "wlt_project", want: ScopeLocal},
+		{name: "explicit local account key", requested: ScopeLocal, token: "ak_account", want: ScopeLocal},
+		{name: "project token cannot be global", requested: ScopeUser, token: "wlt_project", wantError: true},
+		{name: "unknown scope", requested: "workspace", token: "ak_account", wantError: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := setupScope(test.requested, test.token)
+			if test.wantError {
+				if err == nil {
+					t.Fatalf("setupScope()=%q want error", got)
+				}
+				return
+			}
+			if err != nil || got != test.want {
+				t.Fatalf("setupScope()=(%q,%v) want (%q,nil)", got, err, test.want)
+			}
+		})
+	}
+}

--- a/internal/hookinstaller/hookinstaller.go
+++ b/internal/hookinstaller/hookinstaller.go
@@ -27,9 +27,13 @@ import (
 // Harness selects which harness's hook config to write.
 type Harness string
 
+type Scope string
+
 const (
 	HarnessClaude Harness = "claude"
 	HarnessCodex  Harness = "codex"
+	ScopeLocal    Scope   = "local"
+	ScopeUser     Scope   = "user"
 )
 
 // hookMarker identifies agen8's own entries inside a shared hooks file, so
@@ -39,6 +43,9 @@ const hookMarker = "/hooks/attention"
 // Options configures Install.
 type Options struct {
 	Harness Harness
+	// Scope controls whether Claude hooks apply to one project or every project.
+	// Codex hooks are already user-scoped and ignore this field.
+	Scope Scope
 	// BaseURL of the agen8 daemon, e.g. http://127.0.0.1:7777 or a hosted URL.
 	BaseURL string
 	// Token is the bearer credential the hook authenticates with (an MCP API
@@ -60,13 +67,17 @@ type Result struct {
 	Path string
 }
 
-// MCPOptions configures private, project-local Claude MCP provisioning.
+// MCPOptions configures private Claude MCP provisioning.
 type MCPOptions struct {
 	// BaseURL of the agen8 daemon, e.g. http://127.0.0.1:7777 or a hosted URL.
 	BaseURL string
 	// Token is the bearer credential Claude Code will send to /mcp.
 	Token string
-	// ProjectDir identifies the local-scope project in Claude Code's user config.
+	// Scope is local or user. The zero value preserves the historical local
+	// behavior for internal project-bound provisioning.
+	Scope Scope
+	// ProjectDir is Claude's working directory. Local scope binds to it; user
+	// scope uses it only to remove a stale local override.
 	ProjectDir string
 	// ServerName is the mcpServers key. Defaults to "agen8".
 	ServerName string
@@ -81,6 +92,7 @@ type MCPResult struct {
 	Path       string
 	ServerName string
 	URL        string
+	Scope      Scope
 }
 
 type claudeCommandRunner func(ctx context.Context, projectDir string, args ...string) ([]byte, error)
@@ -157,7 +169,7 @@ func Install(opts Options) (Result, error) {
 }
 
 // InstallClaudeMCP uses Claude Code's config manager to replace Agen8's
-// private, project-local MCP entry in ~/.claude.json. Claude settings files do
+// private MCP entry in ~/.claude.json. Claude settings files do
 // not accept mcpServers, while a project .mcp.json would expose the bearer
 // credential to version control. Delegating the merge to `claude mcp` preserves
 // every unrelated setting and follows Claude's current config schema.
@@ -168,6 +180,10 @@ func InstallClaudeMCP(opts MCPOptions) (MCPResult, error) {
 	}
 	if strings.TrimSpace(opts.Token) == "" {
 		return MCPResult{}, fmt.Errorf("claude mcp install: --token is required (an agen8 API key, ak_...)")
+	}
+	scope, err := claudeScope(opts.Scope)
+	if err != nil {
+		return MCPResult{}, err
 	}
 	projectDir := strings.TrimSpace(opts.ProjectDir)
 	if projectDir == "" {
@@ -180,7 +196,7 @@ func InstallClaudeMCP(opts MCPOptions) (MCPResult, error) {
 	if serverName == "" {
 		serverName = "agen8"
 	}
-	projectDir, err := filepath.Abs(projectDir)
+	projectDir, err = filepath.Abs(projectDir)
 	if err != nil {
 		return MCPResult{}, fmt.Errorf("claude mcp install: resolve project dir: %w", err)
 	}
@@ -213,14 +229,39 @@ func InstallClaudeMCP(opts MCPOptions) (MCPResult, error) {
 	if run == nil {
 		run = runClaudeCommand
 	}
-	removeOutput, removeErr := run(ctx, projectDir, "mcp", "remove", "--scope", "local", serverName)
-	if removeErr != nil && !strings.Contains(string(removeOutput), "No project-local MCP server found") {
-		return MCPResult{}, fmt.Errorf("claude mcp install: remove existing server: %w", removeErr)
+	if scope == ScopeUser {
+		// A local server shadows a user server with the same name. Remove Agen8's
+		// current-project override before installing the account-level connection.
+		if err := removeClaudeMCP(ctx, run, projectDir, ScopeLocal, serverName); err != nil {
+			return MCPResult{}, err
+		}
 	}
-	if _, err := run(ctx, projectDir, "mcp", "add-json", "--scope", "local", serverName, string(serverJSON)); err != nil {
+	if err := removeClaudeMCP(ctx, run, projectDir, scope, serverName); err != nil {
+		return MCPResult{}, err
+	}
+	if _, err := run(ctx, projectDir, "mcp", "add-json", "--scope", string(scope), serverName, string(serverJSON)); err != nil {
 		return MCPResult{}, fmt.Errorf("claude mcp install: add server: %w", err)
 	}
-	return MCPResult{Path: claudeLocalConfigPath(), ServerName: serverName, URL: mcpURL}, nil
+	return MCPResult{Path: claudeLocalConfigPath(), ServerName: serverName, URL: mcpURL, Scope: scope}, nil
+}
+
+func claudeScope(scope Scope) (Scope, error) {
+	scope = Scope(strings.ToLower(strings.TrimSpace(string(scope))))
+	if scope == "" {
+		return ScopeLocal, nil
+	}
+	if scope != ScopeLocal && scope != ScopeUser {
+		return "", fmt.Errorf("claude setup scope must be local or user")
+	}
+	return scope, nil
+}
+
+func removeClaudeMCP(ctx context.Context, run claudeCommandRunner, projectDir string, scope Scope, serverName string) error {
+	output, err := run(ctx, projectDir, "mcp", "remove", "--scope", string(scope), serverName)
+	if err == nil || strings.Contains(strings.ToLower(string(output)), "no ") && strings.Contains(strings.ToLower(string(output)), "mcp server found") {
+		return nil
+	}
+	return fmt.Errorf("claude mcp install: remove %s server: %w", scope, err)
 }
 
 func runClaudeCommand(ctx context.Context, projectDir string, args ...string) ([]byte, error) {
@@ -282,11 +323,17 @@ func hookCommand(baseURL, token, harness string, spec hookSpec) string {
 	)
 }
 
-// installClaude merges agen8's hook entries into <project>/.claude/settings.local.json.
-// settings.local.json (not settings.json) keeps the embedded token out of git.
+// installClaude merges Agen8's hooks into private Claude settings. Local scope
+// uses <project>/.claude/settings.local.json; user scope uses
+// ~/.claude/settings.json and removes Agen8's local hooks in the current folder
+// because Claude gives local settings precedence over user settings.
 // The merge is surgical: within each event, any existing group containing an
 // agen8 attention command is replaced; everything else is preserved verbatim.
 func installClaude(opts Options, baseURL string) (Result, error) {
+	scope, err := claudeScope(opts.Scope)
+	if err != nil {
+		return Result{}, fmt.Errorf("hooks install: %w", err)
+	}
 	projectDir := strings.TrimSpace(opts.ProjectDir)
 	if projectDir == "" {
 		wd, err := os.Getwd()
@@ -296,6 +343,19 @@ func installClaude(opts Options, baseURL string) (Result, error) {
 		projectDir = wd
 	}
 	path := filepath.Join(projectDir, ".claude", "settings.local.json")
+	if scope == ScopeUser {
+		homeDir := strings.TrimSpace(opts.HomeDir)
+		if homeDir == "" {
+			homeDir, err = os.UserHomeDir()
+			if err != nil {
+				return Result{}, fmt.Errorf("hooks install: resolve home directory: %w", err)
+			}
+		}
+		if err := removeClaudeHooks(filepath.Join(projectDir, ".claude", "settings.local.json")); err != nil {
+			return Result{}, err
+		}
+		path = filepath.Join(homeDir, ".claude", "settings.json")
+	}
 	if err := validateHookConfigPath(path); err != nil {
 		return Result{}, fmt.Errorf("hooks install: validate %s: %w", path, err)
 	}
@@ -315,6 +375,44 @@ func installClaude(opts Options, baseURL string) (Result, error) {
 		return Result{}, err
 	}
 	return Result{Harness: HarnessClaude, Path: path}, nil
+}
+
+func removeClaudeHooks(path string) error {
+	raw, err := readHookConfig(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("hooks install: read %s: %w", path, err)
+	}
+	settings := map[string]any{}
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		return fmt.Errorf("hooks install: %s exists but is not valid JSON: %w", path, err)
+	}
+	hooks, _ := settings["hooks"].(map[string]any)
+	changed := false
+	for event, groups := range hooks {
+		filtered := withoutAgen8Groups(groups)
+		original, _ := groups.([]any)
+		if len(filtered) != len(original) {
+			changed = true
+		}
+		if len(filtered) == 0 {
+			delete(hooks, event)
+		} else {
+			hooks[event] = filtered
+		}
+	}
+	if !changed {
+		return nil
+	}
+	if len(hooks) == 0 {
+		delete(settings, "hooks")
+	}
+	if err := writeJSONFile(path, settings); err != nil {
+		return fmt.Errorf("hooks install: remove local Agen8 hooks: %w", err)
+	}
+	return nil
 }
 
 // installCodex merges agen8's hook entries into ~/.codex/hooks.json — the

--- a/internal/hookinstaller/hookinstaller_test.go
+++ b/internal/hookinstaller/hookinstaller_test.go
@@ -111,6 +111,51 @@ func TestInstallClaudeWritesSettingsLocal(t *testing.T) {
 	}
 }
 
+func TestInstallClaudeUserScopeMigratesCurrentLocalHooks(t *testing.T) {
+	home := t.TempDir()
+	project := t.TempDir()
+	localPath := filepath.Join(project, ".claude", "settings.local.json")
+	if err := os.MkdirAll(filepath.Dir(localPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	local := `{"permissions":{"allow":["Bash"]},"hooks":{"Stop":[{"hooks":[{"type":"command","command":"echo user"}]},{"hooks":[{"type":"command","command":"curl http://old/hooks/attention"}]}]}}`
+	if err := os.WriteFile(localPath, []byte(local), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := Install(Options{
+		Harness:    HarnessClaude,
+		Scope:      ScopeUser,
+		BaseURL:    "https://agen8.example.com",
+		Token:      "ak_user",
+		ProjectDir: project,
+		HomeDir:    home,
+	})
+	if err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	userPath := filepath.Join(home, ".claude", "settings.json")
+	if result.Path != userPath {
+		t.Fatalf("path=%q want %q", result.Path, userPath)
+	}
+	userConfig := readJSON(t, userPath)
+	if len(eventGroups(t, userConfig, "Stop")) != 1 {
+		t.Fatalf("user Stop hooks were not installed")
+	}
+	cleanedLocal := readJSON(t, localPath)
+	if _, ok := cleanedLocal["permissions"]; !ok {
+		t.Fatal("local non-hook settings were removed")
+	}
+	groups := eventGroups(t, cleanedLocal, "Stop")
+	if len(groups) != 1 {
+		t.Fatalf("local Stop groups=%d want only user hook", len(groups))
+	}
+	command := groups[0].(map[string]any)["hooks"].([]any)[0].(map[string]any)["command"]
+	if command != "echo user" {
+		t.Fatalf("local user hook changed: %v", command)
+	}
+}
+
 func TestInstallClaudeIsIdempotentAndPreservesUserHooks(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".claude", "settings.local.json")
@@ -200,6 +245,42 @@ func TestInstallClaudeMCPUsesPrivateLocalScopeAndReplacesOnlyAgen8(t *testing.T)
 	headers := server["headers"].(map[string]any)
 	if headers["Authorization"] != "Bearer ak_new" {
 		t.Fatalf("Authorization header = %v", headers["Authorization"])
+	}
+}
+
+func TestInstallClaudeMCPUserScopeRemovesLocalOverride(t *testing.T) {
+	dir := t.TempDir()
+	var calls [][]string
+	run := func(_ context.Context, _ string, args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		return nil, nil
+	}
+	result, err := InstallClaudeMCP(MCPOptions{
+		BaseURL:    "https://agen8.example.com",
+		Token:      "ak_user",
+		Scope:      ScopeUser,
+		ProjectDir: dir,
+		runCommand: run,
+	})
+	if err != nil {
+		t.Fatalf("InstallClaudeMCP: %v", err)
+	}
+	if result.Scope != ScopeUser {
+		t.Fatalf("scope=%q want user", result.Scope)
+	}
+	want := []string{
+		"mcp remove --scope local agen8",
+		"mcp remove --scope user agen8",
+		"mcp add-json --scope user agen8",
+	}
+	if len(calls) != len(want) {
+		t.Fatalf("calls=%d want %d: %+v", len(calls), len(want), calls)
+	}
+	for index, prefix := range want {
+		got := strings.Join(calls[index], " ")
+		if !strings.HasPrefix(got, prefix) {
+			t.Fatalf("call[%d]=%q want prefix %q", index, got, prefix)
+		}
 	}
 }
 

--- a/web/src/components/dashboard/GettingStartedCard.tsx
+++ b/web/src/components/dashboard/GettingStartedCard.tsx
@@ -112,7 +112,7 @@ export default function GettingStartedCard({ projectId }: { projectId: string | 
             {connectCommand ? (
               <>
                 <p className="m-0 mb-1.5 text-[0.75rem] text-[var(--text-3)]">
-                  This token is shown once — the command below already includes it.
+                  This token is shown once. Claude uses this account-level connection in every project.
                 </p>
                 <CommandLine value={connectCommand} />
               </>
@@ -155,7 +155,7 @@ export default function GettingStartedCard({ projectId }: { projectId: string | 
             <Check size={11} className="text-[var(--green)]" aria-hidden />
             <span>
               {harness === 'claude'
-                ? 'The Claude setup command installs project attention hooks.'
+                ? 'The Claude setup command installs account-level attention hooks once.'
                 : <>Install attention reporting with <code className="text-[var(--text-2)]">agen8 hooks install</code>.</>}
             </span>
           </div>

--- a/web/src/components/settings/AccountSettings.tsx
+++ b/web/src/components/settings/AccountSettings.tsx
@@ -426,12 +426,12 @@ export function AccountMCPAccessSection() {
                 />
                 <SetupSnippet
                   title="Claude Code setup"
-                  description="Run inside the project. Installs the skill, attention hooks, and local-scope MCP connection."
+                  description="Run once. Connects every Claude project and installs account-level skills and attention hooks."
                   value={snippets.claudeCommand}
                 />
                 <SetupSnippet
                   title="Claude Code hooks repair"
-                  description="Lower-level repair command when only the project hooks need replacing."
+                  description="Lower-level project repair for a legacy local hook configuration."
                   value={snippets.hooksClaudeCommand}
                 />
                 <SetupSnippet

--- a/web/src/lib/mcpSetup.test.ts
+++ b/web/src/lib/mcpSetup.test.ts
@@ -17,7 +17,7 @@ describe('buildMCPSetup', () => {
       },
     })
     expect(setup.codexCommand).toBe("export AGEN8_MCP_TOKEN='ak_test_secret'\ncodex mcp add agen8 --url 'http://127.0.0.1:7777/mcp' --bearer-token-env-var AGEN8_MCP_TOKEN")
-    expect(setup.claudeCommand).toBe("agen8 client setup --harness claude --url 'http://127.0.0.1:7777' --token 'ak_test_secret'")
+    expect(setup.claudeCommand).toBe("agen8 client setup --harness claude --scope user --url 'http://127.0.0.1:7777' --token 'ak_test_secret'")
     expect(setup.hooksClaudeCommand).toBe("agen8 hooks install --harness claude --url 'http://127.0.0.1:7777' --token 'ak_test_secret'")
     expect(setup.hooksCodexCommand).toBe("agen8 hooks install --harness codex --url 'http://127.0.0.1:7777' --token 'ak_test_secret'")
   })

--- a/web/src/lib/mcpSetup.ts
+++ b/web/src/lib/mcpSetup.ts
@@ -36,7 +36,7 @@ export function buildMCPSetup(secret: string, origin = browserOrigin()): MCPSetu
       },
     }, null, 2),
     codexCommand: `export AGEN8_MCP_TOKEN=${shellQuote(token)}\ncodex mcp add ${SERVER_NAME} --url ${shellQuote(url)} --bearer-token-env-var AGEN8_MCP_TOKEN`,
-    claudeCommand: `agen8 client setup --harness claude --url ${shellQuote(daemonOrigin)} --token ${shellQuote(token)}`,
+    claudeCommand: `agen8 client setup --harness claude --scope user --url ${shellQuote(daemonOrigin)} --token ${shellQuote(token)}`,
     hooksClaudeCommand: `agen8 hooks install --harness claude --url ${shellQuote(daemonOrigin)} --token ${shellQuote(token)}`,
     hooksCodexCommand: `agen8 hooks install --harness codex --url ${shellQuote(daemonOrigin)} --token ${shellQuote(token)}`,
   }


### PR DESCRIPTION
## Summary
- install account API-key connections at Claude user scope
- keep project-bound link tokens constrained to local scope
- install account-level attention hooks and remove stale Agen8 local overrides
- make reruns rotate credentials and repair partial setup
- update dashboard, account, and operator guidance to distinguish account and project setup

## Verification
- go test ./...
- go vet ./...
- staticcheck ./...
- gosec -quiet -exclude-generated ./...
- npm test
- npm run lint -- --max-warnings 0
- npm run build