### PR TITLE
Migrate stale Claude project-scope Agen8 entries

### DIFF
--- a/internal/hookinstaller/hookinstaller.go
+++ b/internal/hookinstaller/hookinstaller.go
@@ -230,9 +230,14 @@ func InstallClaudeMCP(opts MCPOptions) (MCPResult, error) {
 		run = runClaudeCommand
 	}
 	if scope == ScopeUser {
-		// A local server shadows a user server with the same name. Remove Agen8's
-		// current-project override before installing the account-level connection.
+		// Local and project servers shadow a user server with the same name.
+		// Remove Agen8's current-folder overrides before installing the
+		// account-level connection. Claude's config manager edits only this server
+		// and preserves every unrelated entry in .mcp.json and ~/.claude.json.
 		if err := removeClaudeMCP(ctx, run, projectDir, ScopeLocal, serverName); err != nil {
+			return MCPResult{}, err
+		}
+		if err := removeClaudeMCP(ctx, run, projectDir, Scope("project"), serverName); err != nil {
 			return MCPResult{}, err
 		}
 	}

--- a/internal/hookinstaller/hookinstaller_test.go
+++ b/internal/hookinstaller/hookinstaller_test.go
@@ -270,6 +270,7 @@ func TestInstallClaudeMCPUserScopeRemovesLocalOverride(t *testing.T) {
 	}
 	want := []string{
 		"mcp remove --scope local agen8",
+		"mcp remove --scope project agen8",
 		"mcp remove --scope user agen8",
 		"mcp add-json --scope user agen8",
 	}


### PR DESCRIPTION
## Summary
- remove stale local and project-scope Agen8 entries before user-scope setup
- delegate surgical config edits to the Claude CLI
- preserve unrelated shared MCP servers
- prove the migration with the real Claude CLI in an isolated home/project

## Verification
- go test ./internal/hookinstaller ./internal/clientsetup ./cmd/agen8
- real `claude mcp get agen8` reports User config after migrating a project `.mcp.json`
- unrelated `.mcp.json` server remains unchanged